### PR TITLE
feat: Next.js、Python、開発環境用の.gitignoreファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,43 @@
+# ===========================
+# Node.js / Next.js
+# ===========================
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# Testing
+coverage/
+*.lcov
+.nyc_output
+
+# Next.js
+.next/
+out/
+build/
+dist/
+
+# Production
+*.pid
+*.seed
+*.pid.lock
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
+# ===========================
+# Python / FastAPI
+# ===========================
 # Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[codz]
+*.py[cod]
 *$py.class
 
 # C extensions
@@ -26,15 +63,15 @@ share/python-wheels/
 *.egg
 MANIFEST
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
+# Virtual environments
+venv/
+env/
+ENV/
+.venv
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
 
 # Unit test / coverage reports
 htmlcov/
@@ -51,108 +88,118 @@ coverage.xml
 .pytest_cache/
 cover/
 
-# Translations
-*.mo
-*.pot
+# FastAPI
+.pytest_cache/
 
-# Django stuff:
-*.log
-local_settings.py
+# ===========================
+# Database
+# ===========================
+*.db
+*.sqlite
+*.sqlite3
 db.sqlite3
 db.sqlite3-journal
 
-# Flask stuff:
-instance/
-.webassets-cache
+# ===========================
+# Docker
+# ===========================
+*.log
+.docker/
 
-# Scrapy stuff:
-.scrapy
+# ===========================
+# IDE / Editors
+# ===========================
+# VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
 
+# IntelliJ / JetBrains
+.idea/
+*.iml
+*.iws
+*.ipr
+
+# Cursor AI
+.cursorignore
+.cursorindexingignore
+
+# ===========================
+# OS
+# ===========================
+# macOS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+.AppleDouble
+.LSOverride
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*.lnk
+
+# Linux
+*~
+.directory
+.Trash-*
+
+# ===========================
+# Environment variables
+# ===========================
+.env
+.env.*
+!.env.example
+.envrc
+
+# ===========================
+# Temporary files
+# ===========================
+*.tmp
+*.temp
+.tmp/
+.temp/
+tmp/
+temp/
+
+# ===========================
+# Project specific
+# ===========================
+# Audio files (if storing locally during development)
+*.mp3
+*.wav
+*.m4a
+!public/sounds/*.mp3
+
+# Uploaded files
+uploads/
+media/
+
+# ===========================
+# Documentation
+# ===========================
 # Sphinx documentation
 docs/_build/
 
-# PyBuilder
-.pybuilder/
-target/
+# MkDocs
+/site
 
+# ===========================
+# Other Python tools
+# ===========================
 # Jupyter Notebook
 .ipynb_checkpoints
 
 # IPython
 profile_default/
 ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#uv.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-#poetry.toml
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
-#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
-#pdm.lock
-#pdm.toml
-.pdm-python
-.pdm-build/
-
-# pixi
-#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
-#pixi.lock
-#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
-#   in the .venv directory. It is recommended not to include this directory in version control.
-.pixi
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.envrc
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
 
 # mypy
 .mypy_cache/
@@ -165,44 +212,20 @@ dmypy.json
 # pytype static type analyzer
 .pytype/
 
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
-
-# Abstra
-# Abstra is an AI-powered process automation framework.
-# Ignore directories containing user credentials, local state, and settings.
-# Learn more at https://abstra.io/docs
-.abstra/
-
-# Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
-#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
-#  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
-
-# Ruff stuff:
+# Ruff
 .ruff_cache/
 
-# PyPI configuration file
-.pypirc
+# ===========================
+# Package managers
+# ===========================
+# npm
+package-lock.json
+!frontend/package-lock.json
 
-# Cursor
-#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
-#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
-#  refer to https://docs.cursor.com/context/ignore-files
-.cursorignore
-.cursorindexingignore
+# yarn
+yarn.lock
+!frontend/yarn.lock
 
-# Marimo
-marimo/_static/
-marimo/_lsp/
-__marimo__/
-.claude/
+# pnpm
+pnpm-lock.yaml
+!frontend/pnpm-lock.yaml


### PR DESCRIPTION
## 📝 やったこと
フロントエンド（Next.js）とバックエンド（FastAPI）の両方に対応した.gitignoreファイルを追加しました。

### Node.js/Next.js関連
- node_modules/、.next/などの除外設定
- npm/yarn/pnpmのログファイル除外

### Python/FastAPI関連  
- __pycache__/、venv/などの除外設定
- pytest、coverageの一時ファイル除外

### 開発環境関連
- VSCode、IntelliJ IDEA、Cursor AIの設定ファイル除外
- Docker関連のログファイル除外

### その他
- OS固有ファイル（.DS_Store、Thumbs.db等）除外
- 環境変数ファイル（.env）除外（.env.exampleは保持）
- データベースファイル（*.db、*.sqlite3）除外
- 一時ファイル、アップロードファイル除外

## 🔗 関連 Issue
close #13

## ✅ チェックリスト
- [ ] 必要なファイルが誤って除外設定に含まれていないか
- [ ] package-lock.jsonなど、プロジェクトで必要なファイルが適切に扱われているか
- [ ] チーム全員の開発環境（Mac/Windows/Linux）で問題ないか

## 💭 補足・相談

- 既存のPython専用.gitignoreを、フルスタック開発用に更新
- 音声ファイルなどプロジェクト固有の除外設定も追加

