### PR TITLE
Feature/be 003 cors setup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,33 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from app.core.config import settings
 
-app = FastAPI()
+# FastAPIアプリケーション作成
+app = FastAPI(
+    title="BUD Backend API",
+    description="子ども英語チャレンジサポートアプリのバックエンドAPI",
+    version="1.0.0"
+)
+
+# CORS設定
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.allowed_hosts_list,  # config.pyから読み込み
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/")
 async def root():
-    return {"message": "Section9 TeamC Backend API"}
+    return {"message": "BUD Backend API is running"}
+
+
+@app.get("/health")
+async def health_check():
+    return {
+        "status": "healthy", 
+        "service": "bud-backend",
+        "version": "1.0.0"
+    }

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -9,6 +9,11 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
-const eslintConfig = [...compat.extends('next/core-web-vitals', 'next/typescript')];
+const eslintConfig = [
+  {
+    ignores: ['.next/**', 'node_modules/**', 'dist/**', 'build/**'],
+  },
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+];
 
 export default eslintConfig;


### PR DESCRIPTION
## 📝 やったこと
- バックエンドにCORS設定を追加
- ESLint設定を修正して.nextフォルダを除外
- ヘルスチェックAPIエンドポイントを追加

## 🔗 関連 Issue
close #79 （該当するIssue番号があれば記入）

## 📸 スクショ
### API動作確認
- http://localhost:8000/health にアクセス可能
- http://localhost:8000/docs でSwagger UI表示
- CORSエラーが解消されフロントエンドからAPI呼び出し可能

### ESLint修正結果
- 1577個のエラー・警告 → 0個に改善
- .nextフォルダが正常に除外されている

## ✅ チェックリスト
- [x] FastAPI開発サーバーの動作確認済み
- [x] /health エンドポイントの動作確認済み
- [x] /docs (Swagger UI) の表示確認済み
- [x] ESLintエラーの解消確認済み
- [x] フロントエンドからのCORS接続テスト済み

## 💭 補足・相談
### CORS設定詳細
- localhost:3000 からのアクセスを許可
- config.py の ALLOWED_HOSTS 設定を活用
- 全HTTPメソッド (GET, POST, PUT, DELETE) に対応
- 認証情報 (Cookies) の送信を許可

### ESLint設定改善
- eslint.config.mjs で .next/** を ignores に追加
- Next.js自動生成ファイルをESLintチェック対象から除外
- 開発効率向上とエラー解消を両立

## 🚀 マージ後にやること
- 他のメンバーに環境構築完了の連絡
- 次タスク（BE-004-env-config）の確認
- フロントエンドからバックエンドAPI呼び出しのテスト