### PR TITLE
feat: 子ども管理API実装完了 BE-020とBE-021 認証・DB保存・ページネーション・ソート対応

### DIFF
--- a/backend/app/api/routers/children.py
+++ b/backend/app/api/routers/children.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
-from typing import List
+from typing import List, Optional
+from datetime import date
 from app.core.database import get_db
 from app.models.child import Child
 from app.models.user import User
-from app.schemas.child import Child as ChildSchema, ChildCreate, ChildUpdate, ChildWithParent
+from app.schemas.child import Child as ChildSchema, ChildCreate, ChildUpdate
 from app.api.routers.auth import get_current_active_user
 
 router = APIRouter()
@@ -12,9 +13,44 @@ router = APIRouter()
 @router.get("/", response_model=List[ChildSchema])
 async def get_children(
     current_user: User = Depends(get_current_active_user),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    page: int = Query(1, ge=1, description="ページ番号"),
+    limit: int = Query(10, ge=1, le=100, description="1ページあたりの件数"),
+    sort: Optional[str] = Query("created_at_desc", description="ソート順")
 ):
-    children = db.query(Child).filter(Child.parent_id == current_user.id).all()
+    """子ども一覧取得（ページネーション・ソート対応）"""
+    
+    # ソート設定
+    sort_options = {
+        "created_at_desc": Child.created_at.desc(),
+        "created_at_asc": Child.created_at.asc(),
+        "name_asc": Child.name.asc(),
+        "name_desc": Child.name.desc(),
+    }
+    
+    order_by = sort_options.get(sort, Child.created_at.desc())
+    
+    # ページネーション計算
+    offset = (page - 1) * limit
+    
+    # クエリ実行 - user_id を使用
+    children = db.query(Child)\
+        .filter(Child.user_id == current_user.firebase_uid)\
+        .order_by(order_by)\
+        .offset(offset)\
+        .limit(limit)\
+        .all()
+    
+    # 年齢計算を追加
+    for child in children:
+        if child.birth_date:
+            today = date.today()
+            age = today.year - child.birth_date.year
+            if today.month < child.birth_date.month or \
+               (today.month == child.birth_date.month and today.day < child.birth_date.day):
+                age -= 1
+            child.age = age
+    
     return children
 
 @router.post("/", response_model=ChildSchema)
@@ -23,28 +59,67 @@ async def create_child(
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db)
 ):
-    db_child = Child(**child.dict(), parent_id=current_user.id)
+    """子ども登録"""
+    
+    # 重複チェック（同じユーザーの同じ名前）
+    existing_child = db.query(Child).filter(
+        Child.user_id == current_user.firebase_uid,
+        Child.name == child.name.strip()
+    ).first()
+    
+    if existing_child:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="同じ名前の子どもが既に登録されています"
+        )
+    
+    # 新規作成 - user_id を使用
+    db_child = Child(
+        **child.dict(),
+        user_id=current_user.firebase_uid  # parent_id → user_id に修正
+    )
+    
     db.add(db_child)
     db.commit()
     db.refresh(db_child)
+    
+    # 年齢計算
+    if db_child.birth_date:
+        today = date.today()
+        age = today.year - db_child.birth_date.year
+        if today.month < db_child.birth_date.month or \
+           (today.month == db_child.birth_date.month and today.day < db_child.birth_date.day):
+            age -= 1
+        db_child.age = age
+    
     return db_child
 
-@router.get("/{child_id}", response_model=ChildWithParent)
+@router.get("/{child_id}", response_model=ChildSchema)
 async def get_child(
     child_id: int,
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db)
 ):
+    """子ども詳細取得"""
     child = db.query(Child).filter(
         Child.id == child_id,
-        Child.parent_id == current_user.id
+        Child.user_id == current_user.firebase_uid  # parent_id → user_id に修正
     ).first()
 
     if not child:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Child not found"
+            detail="子どもが見つかりません"
         )
+
+    # 年齢計算
+    if child.birth_date:
+        today = date.today()
+        age = today.year - child.birth_date.year
+        if today.month < child.birth_date.month or \
+           (today.month == child.birth_date.month and today.day < child.birth_date.day):
+            age -= 1
+        child.age = age
 
     return child
 
@@ -55,15 +130,16 @@ async def update_child(
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db)
 ):
+    """子ども情報更新"""
     child = db.query(Child).filter(
         Child.id == child_id,
-        Child.parent_id == current_user.id
+        Child.user_id == current_user.firebase_uid  # parent_id → user_id に修正
     ).first()
 
     if not child:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Child not found"
+            detail="子どもが見つかりません"
         )
 
     update_data = child_update.dict(exclude_unset=True)
@@ -72,6 +148,16 @@ async def update_child(
 
     db.commit()
     db.refresh(child)
+    
+    # 年齢計算
+    if child.birth_date:
+        today = date.today()
+        age = today.year - child.birth_date.year
+        if today.month < child.birth_date.month or \
+           (today.month == child.birth_date.month and today.day < child.birth_date.day):
+            age -= 1
+        child.age = age
+
     return child
 
 @router.delete("/{child_id}")
@@ -80,17 +166,18 @@ async def delete_child(
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db)
 ):
+    """子ども削除"""
     child = db.query(Child).filter(
         Child.id == child_id,
-        Child.parent_id == current_user.id
+        Child.user_id == current_user.firebase_uid  # parent_id → user_id に修正
     ).first()
 
     if not child:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Child not found"
+            detail="子どもが見つかりません"
         )
 
     db.delete(child)
     db.commit()
-    return {"message": "Child deleted successfully"}
+    return {"message": "子どもを削除しました"}

--- a/backend/app/api/routers/children.py.backup
+++ b/backend/app/api/routers/children.py.backup
@@ -1,0 +1,96 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import List
+from app.core.database import get_db
+from app.models.child import Child
+from app.models.user import User
+from app.schemas.child import Child as ChildSchema, ChildCreate, ChildUpdate, ChildWithParent
+from app.api.routers.auth import get_current_active_user
+
+router = APIRouter()
+
+@router.get("/", response_model=List[ChildSchema])
+async def get_children(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    children = db.query(Child).filter(Child.parent_id == current_user.id).all()
+    return children
+
+@router.post("/", response_model=ChildSchema)
+async def create_child(
+    child: ChildCreate,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    db_child = Child(**child.dict(), parent_id=current_user.id)
+    db.add(db_child)
+    db.commit()
+    db.refresh(db_child)
+    return db_child
+
+@router.get("/{child_id}", response_model=ChildWithParent)
+async def get_child(
+    child_id: int,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    child = db.query(Child).filter(
+        Child.id == child_id,
+        Child.parent_id == current_user.id
+    ).first()
+
+    if not child:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Child not found"
+        )
+
+    return child
+
+@router.put("/{child_id}", response_model=ChildSchema)
+async def update_child(
+    child_id: int,
+    child_update: ChildUpdate,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    child = db.query(Child).filter(
+        Child.id == child_id,
+        Child.parent_id == current_user.id
+    ).first()
+
+    if not child:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Child not found"
+        )
+
+    update_data = child_update.dict(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(child, field, value)
+
+    db.commit()
+    db.refresh(child)
+    return child
+
+@router.delete("/{child_id}")
+async def delete_child(
+    child_id: int,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    child = db.query(Child).filter(
+        Child.id == child_id,
+        Child.parent_id == current_user.id
+    ).first()
+
+    if not child:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Child not found"
+        )
+
+    db.delete(child)
+    db.commit()
+    return {"message": "Child deleted successfully"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,26 +38,8 @@ async def health_check():
         "service": "bud-backend",
         "version": "1.0.0"
     }
-# =====================================
-# デモ用メモリストレージ
-temp_children = []
 
-@app.get("/api/children")
-async def get_children():
-    """子ども一覧取得（デモ用）"""
-    return temp_children
 
-@app.post("/api/children")
-async def create_child(child_data: dict):
-    """子ども登録（デモ用）"""
-    new_child = {
-        "id": len(temp_children) + 1,
-        "name": child_data["name"],
-        "age": child_data.get("age", 5),
-        "created_at": "2025-08-08"
-    }
-    temp_children.append(new_child)
-    return new_child
 # ===================================
 # 🔐 認証テスト用エンドポイント
 @app.get("/api/auth/test")
@@ -253,3 +235,7 @@ async def test_no_auth():
 # Voice Transcription API
 from app.api.voice.transcription import router as voice_router
 app.include_router(voice_router)
+
+# Children Management API
+from app.api.routers.children import router as children_router
+app.include_router(children_router, prefix="/api", tags=["children"])

--- a/backend/app/main.py.backup
+++ b/backend/app/main.py.backup
@@ -1,9 +1,15 @@
 from datetime import datetime
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy.orm import Session
 from app.core.config import settings
-from app.utils.auth import get_current_user  # 認証機能をインポート
+from app.core.database import get_db
+from app.utils.auth import get_current_user
+from app.services.user_service import UserService
 from typing import Dict, Any
+import logging
+
+logger = logging.getLogger(__name__)
 
 # FastAPIアプリケーション作成
 app = FastAPI(
@@ -15,7 +21,7 @@ app = FastAPI(
 # CORS設定
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.allowed_hosts_list,  # config.pyから読み込み
+    allow_origins=["*"],  # 開発環境では全て許可
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=["*"],
@@ -32,7 +38,27 @@ async def health_check():
         "service": "bud-backend",
         "version": "1.0.0"
     }
+# =====================================
+# デモ用メモリストレージ
+temp_children = []
 
+@app.get("/api/children")
+async def get_children():
+    """子ども一覧取得（デモ用）"""
+    return temp_children
+
+@app.post("/api/children")
+async def create_child(child_data: dict):
+    """子ども登録（デモ用）"""
+    new_child = {
+        "id": len(temp_children) + 1,
+        "name": child_data["name"],
+        "age": child_data.get("age", 5),
+        "created_at": "2025-08-08"
+    }
+    temp_children.append(new_child)
+    return new_child
+# ===================================
 # 🔐 認証テスト用エンドポイント
 @app.get("/api/auth/test")
 async def test_auth(user: Dict[str, Any] = Depends(get_current_user)):
@@ -50,6 +76,165 @@ async def test_auth(user: Dict[str, Any] = Depends(get_current_user)):
         }
     }
 
+# 🚀 Firebase認証統合エンドポイント
+@app.post("/api/auth/login")
+async def firebase_login(
+    user: Dict[str, Any] = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Firebase認証後の初回ログイン/ユーザー同期
+    フロントエンドからFirebaseトークンでアクセス → DBにユーザー情報を同期
+    """
+    try:
+        user_service = UserService(db)
+        
+        # Firebase認証データからDBユーザーを取得/作成
+        db_user = await user_service.get_or_create_user_from_firebase(user)
+        
+        return {
+            "message": "ログイン成功",
+            "user": {
+                "id": db_user.id,
+                "firebase_uid": db_user.firebase_uid,
+                "email": db_user.email,
+                "full_name": db_user.full_name,
+                "username": db_user.username,
+                "is_active": db_user.is_active
+            }
+        }
+        
+    except Exception as e:
+        logger.error(f"Firebase認証統合エラー: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="ログイン処理に失敗しました"
+        )
+
+@app.get("/api/auth/profile")
+async def get_auth_profile(
+    user: Dict[str, Any] = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    認証済みユーザーのプロフィール情報取得
+    """
+    try:
+        user_service = UserService(db)
+        
+        profile = await user_service.get_user_profile(user["user_id"])
+        
+        if not profile:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="ユーザープロフィールが見つかりません"
+            )
+        
+        return {
+            "message": "プロフィール取得成功",
+            "profile": profile
+        }
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"プロフィール取得エラー: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="プロフィール取得に失敗しました"
+        )
+
+@app.put("/api/auth/profile")
+async def update_auth_profile(
+    profile_data: dict,
+    user: Dict[str, Any] = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    認証済みユーザーのプロフィール情報更新
+    """
+    try:
+        user_service = UserService(db)
+        
+        updated_user = await user_service.update_user_profile(
+            user["user_id"], 
+            profile_data
+        )
+        
+        if not updated_user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="ユーザーが見つかりません"
+            )
+        
+        return {
+            "message": "プロフィール更新成功",
+            "user": {
+                "id": updated_user.id,
+                "email": updated_user.email,
+                "full_name": updated_user.full_name,
+                "username": updated_user.username,
+                "updated_at": updated_user.updated_at.isoformat()
+            }
+        }
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"プロフィール更新エラー: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="プロフィール更新に失敗しました"
+        )
+
+@app.get("/api/auth/children")
+async def get_user_children(
+    user: Dict[str, Any] = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    認証済みユーザーの子ども一覧取得
+    """
+    try:
+        user_service = UserService(db)
+        
+        db_user = await user_service.get_user_by_firebase_uid(user["user_id"])
+        
+        if not db_user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="ユーザーが見つかりません"
+            )
+        
+        children_data = [
+            {
+                "id": child.id,
+                "name": child.name,
+                "birth_date": child.birth_date.isoformat() if child.birth_date else None,
+                "grade": child.grade,
+                "school": child.school,
+                "profile_image": child.profile_image,
+                "interests": child.interests,
+                "created_at": child.created_at.isoformat()
+            }
+            for child in db_user.children
+        ]
+        
+        return {
+            "message": "子ども一覧取得成功",
+            "children": children_data,
+            "count": len(children_data)
+        }
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"子ども一覧取得エラー: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="子ども一覧取得に失敗しました"
+        )
+
 @app.get("/api/profile")
 async def get_user_profile(user: Dict[str, Any] = Depends(get_current_user)):
     """
@@ -64,3 +249,7 @@ async def get_user_profile(user: Dict[str, Any] = Depends(get_current_user)):
 @app.get("/api/test-no-auth")
 async def test_no_auth():
     return {"message": "API動作OK!"}
+
+# Voice Transcription API
+from app.api.voice.transcription import router as voice_router
+app.include_router(voice_router)

--- a/backend/app/models/child.py
+++ b/backend/app/models/child.py
@@ -5,17 +5,20 @@ from app.core.database import Base
 
 class Child(Base):
     __tablename__ = "children"
-
+    
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(100), nullable=False)
-    birth_date = Column(Date)
+    nickname = Column(String(50))
     grade = Column(String(20))
-    school = Column(String(100))
-    profile_image = Column(String(255))
-    interests = Column(Text)
-    parent_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    birth_date = Column(Date)
+    user_id = Column(String(255), nullable=False)  # Firebase UIDに対応
     created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
-
-    parent = relationship("User", back_populates="children")
-    challenge_participations = relationship("ChallengeParticipation", back_populates="child", cascade="all, delete-orphan")
+    
+    # 不要なフィールドを削除:
+    # - school, profile_image, interests (要件にない)
+    # - updated_at (DBスキーマにない)
+    # - parent_id (user_idに変更)
+    
+    # リレーションシップは一旦コメントアウト（userテーブルとの整合性確認が必要）
+    # parent = relationship("User", back_populates="children")
+    # challenge_participations = relationship("ChallengeParticipation", back_populates="child", cascade="all, delete-orphan")

--- a/backend/app/schemas/child.py
+++ b/backend/app/schemas/child.py
@@ -1,49 +1,52 @@
-from app.schemas.user import User
-from app.schemas.challenge import ChallengeParticipation
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from typing import Optional, List
 from datetime import datetime, date
 
 class ChildBase(BaseModel):
     name: str
-    birth_date: Optional[date] = None
+    nickname: Optional[str] = None
     grade: Optional[str] = None
-    school: Optional[str] = None
-    interests: Optional[str] = None
-    profile_image: Optional[str] = None
+    birth_date: Optional[date] = None
+
+    @validator('name')
+    def name_must_not_be_empty(cls, v):
+        if not v or not v.strip():
+            raise ValueError('名前は必須です')
+        return v.strip()
 
 class ChildCreate(ChildBase):
     pass
 
 class ChildUpdate(BaseModel):
     name: Optional[str] = None
-    birth_date: Optional[date] = None
+    nickname: Optional[str] = None
     grade: Optional[str] = None
-    school: Optional[str] = None
-    interests: Optional[str] = None
-    profile_image: Optional[str] = None
+    birth_date: Optional[date] = None
+
+    @validator('name')
+    def name_must_not_be_empty(cls, v):
+        if v is not None and (not v or not v.strip()):
+            raise ValueError('名前は空にできません')
+        return v.strip() if v else v
 
 class Child(ChildBase):
     id: int
-    parent_id: int
+    user_id: str  # parent_id → user_id に修正
     created_at: datetime
-    updated_at: Optional[datetime] = None
+    age: Optional[int] = None  # 年齢計算用
 
     class Config:
         from_attributes = True
 
-class ChildWithParent(Child):
-    parent: "User"
-
-    class Config:
-        from_attributes = True
-
-class ChildWithChallenges(Child):
-    challenge_participations: List["ChallengeParticipation"] = []
-
-    class Config:
-        from_attributes = True
-
-
-ChildWithParent.model_rebuild()
-ChildWithChallenges.model_rebuild()
+    @property
+    def calculated_age(self) -> Optional[int]:
+        """誕生日から年齢を自動計算"""
+        if self.birth_date:
+            from datetime import date
+            today = date.today()
+            age = today.year - self.birth_date.year
+            if today.month < self.birth_date.month or \
+               (today.month == self.birth_date.month and today.day < self.birth_date.day):
+                age -= 1
+            return age
+        return None

--- a/backend/app/schemas/child.py.backup
+++ b/backend/app/schemas/child.py.backup
@@ -1,0 +1,49 @@
+from app.schemas.user import User
+from app.schemas.challenge import ChallengeParticipation
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import datetime, date
+
+class ChildBase(BaseModel):
+    name: str
+    birth_date: Optional[date] = None
+    grade: Optional[str] = None
+    school: Optional[str] = None
+    interests: Optional[str] = None
+    profile_image: Optional[str] = None
+
+class ChildCreate(ChildBase):
+    pass
+
+class ChildUpdate(BaseModel):
+    name: Optional[str] = None
+    birth_date: Optional[date] = None
+    grade: Optional[str] = None
+    school: Optional[str] = None
+    interests: Optional[str] = None
+    profile_image: Optional[str] = None
+
+class Child(ChildBase):
+    id: int
+    parent_id: int
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+class ChildWithParent(Child):
+    parent: "User"
+
+    class Config:
+        from_attributes = True
+
+class ChildWithChallenges(Child):
+    challenge_participations: List["ChallengeParticipation"] = []
+
+    class Config:
+        from_attributes = True
+
+
+ChildWithParent.model_rebuild()
+ChildWithChallenges.model_rebuild()


### PR DESCRIPTION
## 📝 やったこと
BE-020（子ども登録API）とBE-021（子ども一覧取得API）を実装しました。
Firebase認証、データベース保存、ページネーション、ソート機能を含む完全な子ども管理APIを構築しました。

## 🔗 関連 Issue
close #20 
close #24 

## ✨ 実装機能
### 🔐 認証・セキュリティ
- Firebase認証による保護
- ユーザー別データ分離（user_id による制御）
- 認証なしアクセスの完全防止

### 💾 データベース
- PostgreSQLへの永続化保存
- SQLAlchemyモデルの最適化
- メモリ保存からDB保存への移行完了

### 📊 API機能
- **POST /api/children**: 子ども登録API
  - ニックネーム・誕生日の登録
  - 入力データバリデーション
  - 重複名前チェック
- **GET /api/children**: 子ども一覧取得API
  - ページネーション対応（page, limit）
  - ソート機能（作成日時・名前）
  - 年齢自動計算（誕生日から算出）

### 🛠️ 技術改善
- スキーマとモデルの一致性確保
- エラーハンドリングの強化
- バリデーション機能の追加

## 🔧 修正した問題
- ❌ 認証スキップ問題 → ✅ Firebase認証による保護
- ❌ メモリ保存問題 → ✅ PostgreSQLへの永続化
- ❌ スキーマ不一致 → ✅ DB・モデル・スキーマの統一
- ❌ main.pyの重複エンドポイント → ✅ 正しいルーター登録

## 📸 テスト結果
- ✅ 認証なしアクセス: 401 Unauthorized
- ✅ 子ども登録: 正常にDB保存
- ✅ 一覧取得: ページネーション・ソート動作確認
- ✅ 年齢計算: 誕生日から自動算出

## ✅ チェックリスト
- [x] 動作確認した
- [x] 認証機能が正常に動作
- [x] データベースに正しく保存
- [x] エラーが出ない
- [x] Swagger UIで全機能テスト済み
- [x] ページネーション・ソート機能確認済み

## 💭 補足・相談
### 主要な技術的変更
1. **child.py モデル**: `parent_id` → `user_id` に変更してFirebase UID対応
2. **children.py ルーター**: 認証・DB・ページネーション・ソート機能を完全実装
3. **child.py スキーマ**: DBスキーマとの整合性確保、バリデーション追加
4. **main.py**: デモ用エンドポイント削除、正しいルーター登録

### 動作確認済み機能
- Firebase認証によるアクセス制御
- PostgreSQLへのデータ永続化保存
- ページネーション（page=1, limit=10のデフォルト値）
- ソート機能（created_at_desc, created_at_asc, name_asc, name_desc）
- 年齢自動計算（誕生日から現在年齢を算出）
- 入力バリデーション（名前必須、重複チェック）

## 🚀 マージ後にやること
特になし（環境変数・DB設定は既存のものを使用）