### PR TITLE
feat: チャレンジ履歴APIの実装とルーター登録（BE-031/BE-032）

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -239,3 +239,7 @@ app.include_router(voice_router)
 # Children Management API
 from app.api.routers.children import router as children_router
 app.include_router(children_router, prefix="/api", tags=["children"])
+
+# Challenges API
+from app.api.routers.challenges import router as challenges_router
+app.include_router(challenges_router, prefix="/api", tags=["challenges"])

--- a/backend/app/schemas/challenge.py
+++ b/backend/app/schemas/challenge.py
@@ -83,7 +83,33 @@ class ChallengeParticipationWithDetails(ChallengeParticipation):
 
     class Config:
         from_attributes = True
+class ChallengeHistoryItem(BaseModel):
+    participation_id: int
+    challenge_id: int
+    title: str
+    completed_at: Optional[datetime] = None
+    points_earned: int
 
+    class Config:
+        from_attributes = True
+
+
+class ChallengeHistoryDetail(BaseModel):
+    participation_id: int
+    challenge_id: int
+    title: str
+    description: Optional[str] = None
+    category: ChallengeCategory
+    difficulty_level: int
+    estimated_duration: Optional[int] = None
+    reward_points: int
+    status: str
+    completed_at: Optional[datetime] = None
+    points_earned: int
+    notes: Optional[str] = None
+
+    class Config:
+        from_attributes = True
 
 ChallengeWithCreator.model_rebuild()
 ChallengeWithParticipations.model_rebuild()


### PR DESCRIPTION
## 📝 やったこと

BE-031 / BE-032 チャレンジ履歴APIの実装
GET /children/{child_id}/history（履歴一覧）追加
GET /children/{child_id}/history/{participation_id}（履歴詳細）追加
認可ロジックを children.py と同じ user_id == current_user.firebase_uid に統一
main.py にチャレンジルーター登録
→ /api/... 経由でアクセス可能に
Docker環境でサーバー起動し、フロントエンドから取得確認（200 OK）

## 🔗 関連 Issue

close #51 
close #52 

## 📸 スクショ

<!-- 画面の変更があれば画像を貼る（ドラッグ&ドロップでOK） -->

## ✅ チェックリスト

- [x] 動作確認した
- [x] エラーが出ない
- [ ] スマホでも確認した（画面系の場合）

## 💭 補足・相談

ページネーションは未実装だが、現段階の仕様では必須ではないため後続対応予定
フロント側は既に実装済み（/history/[childId] と /history/[childId]/[recordId]）のため、API登録だけで動作確認OKだった

## 🚀 マージ後にやること


