### PR TITLE
feat: FE-024 子ども選択画面の認証機能とAPI連携を完了

### DIFF
--- a/backend/app/api/routers/children.py.backup
+++ b/backend/app/api/routers/children.py.backup
@@ -1,0 +1,183 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy.orm import Session
+from typing import List, Optional
+from datetime import date
+from app.core.database import get_db
+from app.models.child import Child
+from app.models.user import User
+from app.schemas.child import Child as ChildSchema, ChildCreate, ChildUpdate
+from app.api.routers.auth import get_current_active_user
+
+router = APIRouter()
+
+@router.get("/", response_model=List[ChildSchema])
+async def get_children(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+    page: int = Query(1, ge=1, description="ページ番号"),
+    limit: int = Query(10, ge=1, le=100, description="1ページあたりの件数"),
+    sort: Optional[str] = Query("created_at_desc", description="ソート順")
+):
+    """子ども一覧取得（ページネーション・ソート対応）"""
+    
+    # ソート設定
+    sort_options = {
+        "created_at_desc": Child.created_at.desc(),
+        "created_at_asc": Child.created_at.asc(),
+        "name_asc": Child.name.asc(),
+        "name_desc": Child.name.desc(),
+    }
+    
+    order_by = sort_options.get(sort, Child.created_at.desc())
+    
+    # ページネーション計算
+    offset = (page - 1) * limit
+    
+    # クエリ実行 - user_id を使用
+    children = db.query(Child)\
+        .filter(Child.user_id == current_user.firebase_uid)\
+        .order_by(order_by)\
+        .offset(offset)\
+        .limit(limit)\
+        .all()
+    
+    # 年齢計算を追加
+    for child in children:
+        if child.birth_date:
+            today = date.today()
+            age = today.year - child.birth_date.year
+            if today.month < child.birth_date.month or \
+               (today.month == child.birth_date.month and today.day < child.birth_date.day):
+                age -= 1
+            child.age = age
+    
+    return children
+
+@router.post("/", response_model=ChildSchema)
+async def create_child(
+    child: ChildCreate,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    """子ども登録"""
+    
+    # 重複チェック（同じユーザーの同じ名前）
+    existing_child = db.query(Child).filter(
+        Child.user_id == current_user.firebase_uid,
+        Child.name == child.name.strip()
+    ).first()
+    
+    if existing_child:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="同じ名前の子どもが既に登録されています"
+        )
+    
+    # 新規作成 - user_id を使用
+    db_child = Child(
+        **child.dict(),
+        user_id=current_user.firebase_uid  # parent_id → user_id に修正
+    )
+    
+    db.add(db_child)
+    db.commit()
+    db.refresh(db_child)
+    
+    # 年齢計算
+    if db_child.birth_date:
+        today = date.today()
+        age = today.year - db_child.birth_date.year
+        if today.month < db_child.birth_date.month or \
+           (today.month == db_child.birth_date.month and today.day < db_child.birth_date.day):
+            age -= 1
+        db_child.age = age
+    
+    return db_child
+
+@router.get("/{child_id}", response_model=ChildSchema)
+async def get_child(
+    child_id: int,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    """子ども詳細取得"""
+    child = db.query(Child).filter(
+        Child.id == child_id,
+        Child.user_id == current_user.firebase_uid  # parent_id → user_id に修正
+    ).first()
+
+    if not child:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="子どもが見つかりません"
+        )
+
+    # 年齢計算
+    if child.birth_date:
+        today = date.today()
+        age = today.year - child.birth_date.year
+        if today.month < child.birth_date.month or \
+           (today.month == child.birth_date.month and today.day < child.birth_date.day):
+            age -= 1
+        child.age = age
+
+    return child
+
+@router.put("/{child_id}", response_model=ChildSchema)
+async def update_child(
+    child_id: int,
+    child_update: ChildUpdate,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    """子ども情報更新"""
+    child = db.query(Child).filter(
+        Child.id == child_id,
+        Child.user_id == current_user.firebase_uid  # parent_id → user_id に修正
+    ).first()
+
+    if not child:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="子どもが見つかりません"
+        )
+
+    update_data = child_update.dict(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(child, field, value)
+
+    db.commit()
+    db.refresh(child)
+    
+    # 年齢計算
+    if child.birth_date:
+        today = date.today()
+        age = today.year - child.birth_date.year
+        if today.month < child.birth_date.month or \
+           (today.month == child.birth_date.month and today.day < child.birth_date.day):
+            age -= 1
+        child.age = age
+
+    return child
+
+@router.delete("/{child_id}")
+async def delete_child(
+    child_id: int,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db)
+):
+    """子ども削除"""
+    child = db.query(Child).filter(
+        Child.id == child_id,
+        Child.user_id == current_user.firebase_uid  # parent_id → user_id に修正
+    ).first()
+
+    if not child:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="子どもが見つかりません"
+        )
+
+    db.delete(child)
+    db.commit()
+    return {"message": "子どもを削除しました"}

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -27,3 +27,66 @@ class UserService:
             "full_name": name,
             "username": email.split("@")[0]
         }
+
+    async def get_user_by_firebase_uid(self, firebase_uid: str) -> Optional[dict]:
+        """
+        Firebase UIDからユーザー情報を取得
+        """
+        try:
+            logger.info(f"Firebase UIDでユーザー検索: {firebase_uid}")
+            
+            # 一時的にモックユーザー情報を返す
+            mock_user = {
+                "id": 1,
+                "firebase_uid": firebase_uid,
+                "email": "sasaryo0929@gmail.com",
+                "full_name": "ryoko sasagawa",
+                "username": "sasaryo0929"
+            }
+            
+            logger.info(f"ユーザー情報取得成功: {mock_user['email']}")
+            return mock_user
+            
+        except Exception as e:
+            logger.error(f"ユーザー取得エラー: {str(e)}")
+            return None
+
+    async def get_user_children(self, user_id: int) -> list:
+        """
+        ユーザーの子ども一覧を取得
+        """
+        try:
+            logger.info(f"ユーザー{user_id}の子ども一覧取得開始")
+            
+            # モックデータを返す
+            mock_children = [
+                {
+                    "id": 1,
+                    "user_id": user_id,
+                    "name": "ひなた",
+                    "nickname": "ひなたちゃん",
+                    "age": 6,
+                    "grade": "小学1年生",
+                    "birthdate": "2018-04-15",
+                    "created_at": "2024-08-01T10:00:00Z",
+                    "updated_at": "2024-08-01T10:00:00Z"
+                },
+                {
+                    "id": 2,
+                    "user_id": user_id,
+                    "name": "さくら",
+                    "nickname": "さくらちゃん",
+                    "age": 8,
+                    "grade": "小学3年生",
+                    "birthdate": "2016-03-22",
+                    "created_at": "2024-08-01T10:00:00Z",
+                    "updated_at": "2024-08-01T10:00:00Z"
+                }
+            ]
+            
+            logger.info(f"子ども一覧取得成功: {len(mock_children)}件")
+            return mock_children
+            
+        except Exception as e:
+            logger.error(f"子ども一覧取得エラー: {str(e)}")
+            return []

--- a/backend/app/services/user_service.py.backup
+++ b/backend/app/services/user_service.py.backup
@@ -1,0 +1,29 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, text
+from typing import Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+class UserService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def create_or_update_user_from_firebase(self, firebase_user_data: dict) -> dict:
+        """
+        Firebase認証データからユーザー情報を返す（データベース操作なし）
+        """
+        firebase_uid = firebase_user_data.get("user_id")
+        email = firebase_user_data.get("email")
+        name = firebase_user_data.get("name", "")
+        
+        logger.info(f"Firebase認証成功: {email}")
+        
+        # 一時的にデータベース操作をスキップ、認証情報だけ返す
+        return {
+            "id": 1,  # 仮のID
+            "firebase_uid": firebase_uid,
+            "email": email,
+            "full_name": name,
+            "username": email.split("@")[0]
+        }


### PR DESCRIPTION
## 📝 やったこと
FE-024: 子ども選択画面の認証機能とAPI連携を実装
- Firebase認証後の子ども一覧動的表示
- /api/auth/children エンドポイントの実装
- 認証エラーの解消（500→200 OK）
- 子ども選択時の画面遷移処理

## 🔗 関連 Issue
close #94 [issue番号]

## 📸 スクショ
（子ども選択画面のスクリーンショットを添付）

## ✅ チェックリスト
- [x] 動作確認した
- [x] エラーが出ない
- [x] スマホでも確認した
- [x] Firebase認証が正常動作
- [x] 子ども一覧が表示される
- [x] API連携が成功（200 OK）

## 💭 補足・相談
- モックデータで動作（実際のDB接続はBE-021完了後）
- 認証フローは完全に動作するため、他の認証機能開発が可能
- AsyncSession統一により、今後のDB操作が安定

## 🚀 マージ後にやること
- モックデータを実際のDB操作に置き換え