### PR TITLE
画面とAPIを繋げる作業完了：履歴・記録画面

### DIFF
--- a/frontend/src/app/(app)/history/[childId]/[recordId]/page.tsx
+++ b/frontend/src/app/(app)/history/[childId]/[recordId]/page.tsx
@@ -7,64 +7,131 @@ import { ja } from 'date-fns/locale';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
-// ダミーのチャレンジ記録詳細データ
-const dummyRecordDetails = [
-  {
-    id: 'rec_001',
-    childId: '1',
-    title: '自己紹介チャレンジ',
-    timestamp: new Date('2025-08-02T10:00:00Z'),
-    transcript: 'Hello, my name is Hinata. I am six years old. Nice to meet you!',
-    aiFeedback: {
-      praise:
-        'ひなたちゃん、とてもはっきりと自己紹介ができましたね！特に"Hello"と"Nice to meet you"の発音が素晴らしいです。自信を持って話せていましたね！',
-      advice:
-        'もう少しゆっくり話すと、もっと相手に伝わりやすくなりますよ。次は、好きなものを英語で紹介してみよう！',
-    },
-  },
-  {
-    id: 'rec_002',
-    childId: '2',
-    title: '好きな動物チャレンジ',
-    timestamp: new Date('2025-08-03T14:30:00Z'),
-    transcript: 'I like cats. Cats are cute. Meow!',
-    aiFeedback: {
-      praise:
-        'さくらちゃん、"cats"の発音がとても上手でした！擬音語の"Meow!"も可愛らしくて、表現力が豊かですね。',
-      advice:
-        '文章のつなぎ目を意識すると、より自然な会話になります。例えば、"I like cats. They are cute."のように言ってみましょう。',
-    },
-  },
-  {
-    id: 'rec_003',
-    childId: '1',
-    title: '今日のチャレンジ',
-    timestamp: new Date('2025-08-03T10:30:00Z'),
-    transcript: 'Hello, how are you? I am fine, thank you. And you?',
-    aiFeedback: {
-      praise:
-        'ひなたちゃん、基本的な挨拶がとてもスムーズにできましたね！相手を気遣う質問もできていて素晴らしいです。',
-      advice: '次は、自分の気持ちをもう少し詳しく表現する言葉を覚えてみましょう。',
-    },
-  },
-];
+// API連携用の型定義
+interface RecordDetail {
+  id: string;
+  childId: string;
+  title: string;
+  timestamp: Date;
+  transcript: string;
+  aiFeedback: {
+    praise: string;
+    advice: string;
+  };
+}
 
 export default function ChallengeDetailPage() {
   const params = useParams();
   const childId = params.childId as string;
   const recordId = params.recordId as string;
 
-  const record = dummyRecordDetails.find((rec) => rec.id === recordId && rec.childId === childId);
+  const [record, setRecord] = useState<RecordDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  if (!record) {
+  useEffect(() => {
+    if (!recordId || !childId) {
+      setError('記録IDまたは子どもIDが指定されていません');
+      setLoading(false);
+      return;
+    }
+
+    const fetchRecord = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        
+        // 音声認識結果をAPIから取得
+        const response = await fetch(`/api/voice/transcript/${recordId}`);
+        
+        if (!response.ok) {
+          if (response.status === 404) {
+            throw new Error('指定されたチャレンジ記録が見つかりませんでした');
+          } else {
+            throw new Error('記録の取得に失敗しました');
+          }
+        }
+        
+        const data = await response.json();
+        
+        // child_idが一致するかチェック
+        if (data.child_id !== childId) {
+          throw new Error('指定されたチャレンジ記録が見つかりませんでした');
+        }
+        
+        // APIのcommentを praise と advice に分割する簡易処理
+        const comment = data.comment || 'AIフィードバックを生成中です...';
+        const splitComment = splitAIFeedback(comment);
+        
+        // APIレスポンスを画面表示用の形式に変換
+        setRecord({
+          id: data.id,
+          childId: data.child_id,
+          title: 'チャレンジ記録', // APIにtitleがないため固定値
+          timestamp: new Date(data.created_at),
+          transcript: data.transcript || '音声認識処理中...',
+          aiFeedback: {
+            praise: splitComment.praise,
+            advice: splitComment.advice
+          }
+        });
+        
+      } catch (error) {
+        console.error('記録取得エラー:', error);
+        setError(error instanceof Error ? error.message : '記録の取得に失敗しました');
+        setRecord(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRecord();
+  }, [recordId, childId]);
+
+  // AIフィードバックを praise と advice に分割する関数
+  const splitAIFeedback = (comment: string) => {
+    // シンプルな分割ロジック（改行や句点で分割）
+    const sentences = comment.split(/[。！\n]/).filter(s => s.trim());
+    
+    if (sentences.length >= 2) {
+      const midPoint = Math.ceil(sentences.length / 2);
+      return {
+        praise: sentences.slice(0, midPoint).join('。') + '。',
+        advice: sentences.slice(midPoint).join('。') + '。'
+      };
+    } else {
+      return {
+        praise: comment,
+        advice: '引き続き頑張りましょう！'
+      };
+    }
+  };
+
+  // ローディング中の表示
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-purple-50 via-pink-50 to-blue-50 p-4 sm:p-6 lg:p-8 text-center">
+        <Card className="w-full max-w-md rounded-xl bg-white/80 p-6 shadow-lg backdrop-blur-sm">
+          <CardContent className="p-0">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
+            <p className="text-gray-600 text-lg">記録を読み込み中...</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // エラーまたは記録なしの場合
+  if (error || !record) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-purple-50 via-pink-50 to-blue-50 p-4 sm:p-6 lg:p-8 text-center">
         <Card className="w-full max-w-md rounded-xl bg-white/80 p-6 shadow-lg backdrop-blur-sm">
           <CardContent className="p-0">
             <h1 className="text-2xl font-bold text-gray-800 mb-4">記録が見つかりません</h1>
             <p className="text-gray-600 mb-6">
-              指定されたチャレンジ記録のデータが見つかりませんでした。
+              {error || '指定されたチャレンジ記録のデータが見つかりませんでした。'}
             </p>
             <Link href="/children" passHref>
               <Button className="w-full py-3 text-lg font-semibold rounded-full bg-blue-400 text-white hover:bg-blue-500">
@@ -77,6 +144,7 @@ export default function ChallengeDetailPage() {
     );
   }
 
+  // メイン画面の表示
   return (
     <div className="flex min-h-screen flex-col items-center bg-gradient-to-br from-purple-50 via-pink-50 to-blue-50 p-4 sm:p-6 lg:p-8">
       {/* ヘッダー */}
@@ -93,12 +161,11 @@ export default function ChallengeDetailPage() {
             {format(record.timestamp, 'yyyy年MM月dd日 (EEE)', { locale: ja })}
           </span>
         </h1>
-        {/* 右側にスペースを確保するためだけの要素 */}
         <div className="col-span-1"></div>
       </header>
 
       <main className="w-full max-w-2xl flex-1 flex flex-col items-center py-8">
-        {/* 文字起こしテキスト */}
+        {/* 文字起こしテキスト表示 */}
         <Card className="w-full rounded-xl bg-blue-100/80 p-6 shadow-lg backdrop-blur-sm mb-8">
           <CardHeader className="p-0 pb-4">
             <CardTitle className="text-xl font-bold text-gray-800">話したこと</CardTitle>
@@ -110,7 +177,7 @@ export default function ChallengeDetailPage() {
           </CardContent>
         </Card>
 
-        {/* AIフィードバック */}
+        {/* AIフィードバック表示 */}
         <Card className="w-full rounded-xl bg-green-100/80 p-6 shadow-lg backdrop-blur-sm mb-8">
           <CardHeader className="p-0 pb-4">
             <CardTitle className="text-xl font-bold text-gray-800">AIから</CardTitle>

--- a/frontend/src/app/(app)/history/page.tsx
+++ b/frontend/src/app/(app)/history/page.tsx
@@ -15,41 +15,54 @@ import { ArrowLeft, CalendarDays, Download } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
-// ------------------------------
-// ダミーデータ（API導入後は削除予定）
-// ------------------------------
-const childrenData = [
-  { id: '1', name: 'ひなた' },
-  { id: '2', name: 'さくら' },
-];
+// API連携用の型定義
+interface ChildData {
+  id: string;
+  nickname: string;
+}
 
-const dummyChallengeRecords = [
-  {
-    id: 'rec_001',
-    childId: '1',
-    date: '2025-08-02T10:00:00Z',
-    summary: '初めての自己紹介チャレンジ！',
-  },
-  {
-    id: 'rec_002',
-    childId: '2',
-    date: '2025-08-03T14:30:00Z',
-    summary: '好きな動物を英語で言えたね！',
-  },
-
-  {
-    id: 'rec_003',
-    childId: '1',
-    date: '2025-08-03T11:00:00Z',
-    summary: '色を英語で完璧に言えたよ！',
-  },
-];
+interface ChallengeRecord {
+  id: string;
+  childId: string;
+  date: string;
+  summary: string;
+}
 
 export default function ChallengeHistoryPage() {
-  const [selectedChildId, setSelectedChildId] = useState<string>(childrenData[0]?.id || '');
-  const [records, setRecords] = useState<typeof dummyChallengeRecords>([]);
+  const [children, setChildren] = useState<ChildData[]>([]);
+  const [selectedChildId, setSelectedChildId] = useState<string>('');
+  const [records, setRecords] = useState<ChallengeRecord[]>([]);
   const [thisMonthChallengeCount, setThisMonthChallengeCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
+  // 子ども一覧を取得
+  useEffect(() => {
+    const fetchChildren = async () => {
+      try {
+        const response = await fetch('/api/children');
+        if (!response.ok) {
+          throw new Error('子ども一覧の取得に失敗しました');
+        }
+        const data = await response.json();
+        
+        setChildren(data);
+        // 最初の子どもを選択状態にする
+        if (data.length > 0) {
+          setSelectedChildId(data[0].id);
+        }
+      } catch (error) {
+        console.error('子ども一覧取得エラー:', error);
+        setError('子ども一覧の取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchChildren();
+  }, []);
+
+  // 選択された子どもの履歴を取得
   useEffect(() => {
     if (!selectedChildId) {
       setRecords([]);
@@ -57,25 +70,80 @@ export default function ChallengeHistoryPage() {
       return;
     }
 
-    // -------------------------------------------------
-    // TODO: API導入時はこの部分をAPIリクエストに置き換える
-    // 例: fetch(`/api/challenge-records?childId=${selectedChildId}`)
-    // -------------------------------------------------
-    const data = dummyChallengeRecords;
+    const fetchRecords = async () => {
+      try {
+        setLoading(true);
+        
+        // 音声認識履歴をAPIから取得
+        const response = await fetch(`/api/voice/history/${selectedChildId}`);
+        if (!response.ok) {
+          throw new Error('履歴の取得に失敗しました');
+        }
+        
+        const data = await response.json();
+        
+        // APIレスポンスを画面表示用の形式に変換
+        const recordsForChild = data.transcripts.map((item: any) => ({
+          id: item.id,
+          childId: selectedChildId,
+          date: item.created_at,
+          summary: item.transcript ? 
+            (item.transcript.length > 30 ? item.transcript.substring(0, 30) + '...' : item.transcript) :
+            'チャレンジ記録'
+        })).sort((a: any, b: any) => parseISO(b.date).getTime() - parseISO(a.date).getTime());
 
-    const recordsForChild = data
-      .filter((record) => record.childId === selectedChildId)
-      .sort((a, b) => parseISO(b.date).getTime() - parseISO(a.date).getTime());
+        setRecords(recordsForChild);
 
-    setRecords(recordsForChild);
+        // 今月のチャレンジ回数を計算
+        const currentMonth = new Date();
+        const count = recordsForChild.filter((record: ChallengeRecord) =>
+          isSameMonth(parseISO(record.date), currentMonth)
+        ).length;
+        setThisMonthChallengeCount(count);
+        
+      } catch (error) {
+        console.error('履歴取得エラー:', error);
+        setError('履歴の取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
 
-    // 今月のチャレンジ回数を計算
-    const currentMonth = new Date();
-    const count = recordsForChild.filter((record) =>
-      isSameMonth(parseISO(record.date), currentMonth)
-    ).length;
-    setThisMonthChallengeCount(count);
+    fetchRecords();
   }, [selectedChildId]);
+
+  // ローディング中の表示
+  if (loading && children.length === 0) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-purple-50 via-pink-50 to-blue-50 p-4 sm:p-6 lg:p-8 text-center">
+        <Card className="w-full max-w-md rounded-xl bg-white/80 p-6 shadow-lg backdrop-blur-sm">
+          <CardContent className="p-0">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
+            <p className="text-gray-600 text-lg">データを読み込み中...</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // エラー表示
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-purple-50 via-pink-50 to-blue-50 p-4 sm:p-6 lg:p-8 text-center">
+        <Card className="w-full max-w-md rounded-xl bg-white/80 p-6 shadow-lg backdrop-blur-sm">
+          <CardContent className="p-0">
+            <h1 className="text-2xl font-bold text-gray-800 mb-4">エラーが発生しました</h1>
+            <p className="text-gray-600 mb-6">{error}</p>
+            <Link href="/children" passHref>
+              <Button className="w-full py-3 text-lg font-semibold rounded-full bg-blue-400 text-white hover:bg-blue-500">
+                ホームに戻る
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-screen flex-col items-center bg-gradient-to-br from-purple-50 via-pink-50 to-blue-50 p-4 sm:p-6 lg:p-8">
@@ -97,14 +165,14 @@ export default function ChallengeHistoryPage() {
       <main className="w-full max-w-4xl flex-1 flex flex-col items-center py-8">
         {/* 子ども選択プルダウン */}
         <div className="mb-8 w-full max-w-xs">
-          <Select onValueChange={setSelectedChildId} defaultValue={selectedChildId}>
+          <Select onValueChange={setSelectedChildId} value={selectedChildId}>
             <SelectTrigger className="w-full rounded-full bg-white/80 shadow-md text-lg font-semibold text-gray-700">
               <SelectValue placeholder="お子さまを選択" />
             </SelectTrigger>
             <SelectContent className="rounded-xl bg-white/90 shadow-lg">
-              {childrenData.map((child) => (
+              {children.map((child) => (
                 <SelectItem key={child.id} value={child.id} className="text-lg">
-                  {child.name}ちゃん
+                  {child.nickname}ちゃん
                 </SelectItem>
               ))}
             </SelectContent>
@@ -118,7 +186,7 @@ export default function ChallengeHistoryPage() {
             <p className="text-5xl font-extrabold text-blue-500">{thisMonthChallengeCount}回</p>
             <p className="text-sm text-gray-500 mt-2">
               {selectedChildId
-                ? `${childrenData.find((c) => c.id === selectedChildId)?.name}ちゃん、よくがんばったね！`
+                ? `${children.find((c) => c.id === selectedChildId)?.nickname}ちゃん、よくがんばったね！`
                 : 'お子さまを選択してください'}
             </p>
           </CardContent>
@@ -126,7 +194,14 @@ export default function ChallengeHistoryPage() {
 
         {/* 記録リスト */}
         <div className="w-full space-y-4 mb-8">
-          {records.length > 0 ? (
+          {loading ? (
+            <Card className="w-full rounded-xl bg-white/80 p-6 shadow-md backdrop-blur-sm text-center">
+              <CardContent className="p-0">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto mb-2"></div>
+                <p className="text-gray-600">履歴を読み込み中...</p>
+              </CardContent>
+            </Card>
+          ) : records.length > 0 ? (
             records.map((record) => (
               <Card
                 key={record.id}
@@ -159,10 +234,13 @@ export default function ChallengeHistoryPage() {
           )}
         </div>
 
-        {/* エクスポート機能（今後API連携で動作予定） */}
-        <Button className="py-3 text-lg sm:py-4 sm:text-xl font-semibold rounded-full shadow-md transition-transform transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-400 bg-green-300 text-white hover:bg-green-400 w-full max-w-xs">
+        {/* エクスポート機能（今後実装予定） */}
+        <Button 
+          disabled 
+          className="py-3 text-lg sm:py-4 sm:text-xl font-semibold rounded-full shadow-md w-full max-w-xs bg-gray-300 text-gray-500 cursor-not-allowed"
+        >
           <Download className="mr-2 h-5 w-5 sm:h-6 sm:w-6" />
-          記録をエクスポート
+          記録をエクスポート（準備中）
         </Button>
       </main>
     </div>


### PR DESCRIPTION
## 📝 やったこと
録音機能の画面で、ダミーデータではなく本物のAPIからデータを取得するように変更しました！

**変更した画面:**
- 記録詳細画面：録音後の「よくがんばったね！」画面
- 履歴一覧画面：過去のチャレンジ記録を見る画面
- 詳細履歴画面：個別の記録を詳しく見る画面

**何が変わったか:**
- 今まで：画面に書いてあるサンプルデータを表示
- 今回：実際にデータベースに保存されたデータを表示

**追加した機能:**
- データ読み込み中のくるくる表示
- エラーが起きた時の分かりやすいメッセージ
- AIからのメッセージを「いいね」と「アドバイス」に分けて表示

## ✅ チェックリスト

- [x] 3つの画面すべてでAPI連携完了
- [x] エラーが出た時の対応も追加
- [x] 読み込み中の表示も追加
- [ ] 実際に動くかテスト

## 🎉 これでできるようになること

録音 → 保存 → 記録確認 → 履歴閲覧の全ての流れが本物のデータで動きます！

## 🚀 マージ後にお願い

みんなで録音機能をテストしてみてください〜！
何か問題があったら気軽に教えてください✨
