### PR TITLE
fix: format code with Prettier

### DIFF
--- a/frontend/src/app/(app)/challenge/[childId]/page.tsx
+++ b/frontend/src/app/(app)/challenge/[childId]/page.tsx
@@ -2,11 +2,11 @@
 
 import { Button } from '@/components/ui/button';
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
 } from '@/components/ui/dialog';
 import { api } from '@/lib/api';
 import { cn } from '@/lib/utils';
@@ -17,239 +17,239 @@ import { useEffect, useRef, useState } from 'react';
 
 // ダミーの子どもデータ（実際にはDBから取得）
 const childrenData = [
-    { id: '1', name: 'ひなた' },
-    { id: '2', name: 'さくら' },
+  { id: '1', name: 'ひなた' },
+  { id: '2', name: 'さくら' },
 ];
 
 export default function ChallengePage() {
-    const params = useParams();
-    const router = useRouter();
-    const childId = params.childId as string;
-    const childName = childrenData.find((c) => c.id === childId)?.name || 'お子さま';
+  const params = useParams();
+  const router = useRouter();
+  const childId = params.childId as string;
+  const childName = childrenData.find((c) => c.id === childId)?.name || 'お子さま';
 
-    const [isRecording, setIsRecording] = useState(false);
-    const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
-    const [isUploading, setIsUploading] = useState(false);
-    const mediaRecorderRef = useRef<MediaRecorder | null>(null);
-    const audioChunksRef = useRef<Blob[]>([]);
+  const [isRecording, setIsRecording] = useState(false);
+  const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
 
-    const [showMamaPhraseDialog, setShowMamaPhraseDialog] = useState(false);
-    const [showChildPhraseDialog, setShowChildPhraseDialog] = useState(false);
+  const [showMamaPhraseDialog, setShowMamaPhraseDialog] = useState(false);
+  const [showChildPhraseDialog, setShowChildPhraseDialog] = useState(false);
 
-    // 録音開始
-    const startRecording = async () => {
-        try {
-            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-            mediaRecorderRef.current = new MediaRecorder(stream);
-            audioChunksRef.current = [];
+  // 録音開始
+  const startRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaRecorderRef.current = new MediaRecorder(stream);
+      audioChunksRef.current = [];
 
-            mediaRecorderRef.current.ondataavailable = (event) => {
-                audioChunksRef.current.push(event.data);
-            };
+      mediaRecorderRef.current.ondataavailable = (event) => {
+        audioChunksRef.current.push(event.data);
+      };
 
-            mediaRecorderRef.current.onstop = () => {
-                const blob = new Blob(audioChunksRef.current, { type: 'audio/webm' });
-                setAudioBlob(blob);
-                stream.getTracks().forEach((track) => track.stop());
-            };
+      mediaRecorderRef.current.onstop = () => {
+        const blob = new Blob(audioChunksRef.current, { type: 'audio/webm' });
+        setAudioBlob(blob);
+        stream.getTracks().forEach((track) => track.stop());
+      };
 
-            mediaRecorderRef.current.start();
-            setIsRecording(true);
-            setAudioBlob(null);
-        } catch (error) {
-            console.error('マイクへのアクセスに失敗しました:', error);
-            alert('マイクへのアクセスを許可してください。');
-        }
+      mediaRecorderRef.current.start();
+      setIsRecording(true);
+      setAudioBlob(null);
+    } catch (error) {
+      console.error('マイクへのアクセスに失敗しました:', error);
+      alert('マイクへのアクセスを許可してください。');
+    }
+  };
+
+  // 録音停止
+  const stopRecording = () => {
+    if (mediaRecorderRef.current && isRecording) {
+      mediaRecorderRef.current.stop();
+      setIsRecording(false);
+    }
+  };
+
+  // 録音保存
+  const saveRecording = async () => {
+    if (!audioBlob) {
+      alert('保存する録音データがありません。');
+      return;
+    }
+
+    setIsUploading(true);
+
+    try {
+      // サーバーに送信
+      const result = await api.voice.transcribe(audioBlob, childId);
+
+      // 処理完了後の遷移処理
+      router.push(`/record/${result.transcript_id}`);
+    } catch (error) {
+      console.error('録音の保存に失敗しました:', error);
+      alert('録音の保存に失敗しました。もう一度お試しください。');
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (mediaRecorderRef.current && isRecording) {
+        mediaRecorderRef.current.stop();
+      }
     };
+  }, [isRecording]);
 
-    // 録音停止
-    const stopRecording = () => {
-        if (mediaRecorderRef.current && isRecording) {
-            mediaRecorderRef.current.stop();
-            setIsRecording(false);
-        }
-    };
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-start bg-gradient-to-br from-purple-50 via-pink-50 to-blue-50 p-4">
+      {/* ヘッダー */}
+      <header className="w-full max-w-xl flex justify-between items-center mb-4">
+        <Link
+          href="/children"
+          className="flex items-center text-gray-600 hover:text-gray-800 transition-colors"
+        >
+          <XCircle className="h-5 w-5 sm:h-6 sm:w-6 mr-1" />
+          <span className="text-sm sm:text-base font-medium">やめる</span>
+        </Link>
+        <h1 className="flex-1 text-center text-lg font-bold text-gray-800 sm:text-xl">
+          <span className="font-extrabold text-2xl sm:text-3xl">{childName}</span>ちゃん
+          <br className="sm:hidden" />
+          チャレンジ中！
+        </h1>
+        <div className="w-20 sm:w-24"></div>
+      </header>
 
-    // 録音保存
-    const saveRecording = async () => {
-        if (!audioBlob) {
-            alert('保存する録音データがありません。');
-            return;
-        }
+      {/* メインコンテンツ */}
+      <main className="flex flex-1 flex-col items-center justify-center w-full max-w-xl py-4">
+        {/* 録音ボタン */}
+        <div className="flex flex-col items-center">
+          {!audioBlob && (
+            <Button
+              onClick={isRecording ? stopRecording : startRecording}
+              className={cn(
+                'w-40 h-40 sm:w-48 sm:h-48 rounded-full flex flex-col items-center justify-center shadow-xl transition-all duration-300',
+                isRecording
+                  ? 'bg-red-500 hover:bg-red-600 animate-pulse'
+                  : 'bg-blue-400 hover:bg-blue-500'
+              )}
+              size="icon"
+            >
+              {isRecording ? (
+                <>
+                  <Mic className="h-16 w-16 sm:h-20 sm:w-20 text-white" />
+                  <span className="mt-2 text-white text-base sm:text-lg font-semibold">
+                    ストップ
+                  </span>
+                </>
+              ) : (
+                <>
+                  <Mic className="h-16 w-16 sm:h-20 sm:w-20 text-white" />
+                  <span className="mt-2 text-white text-base sm:text-lg font-semibold">
+                    スタート
+                  </span>
+                </>
+              )}
+            </Button>
+          )}
 
-        setIsUploading(true);
-
-        try {
-            // サーバーに送信
-            const result = await api.voice.transcribe(audioBlob, childId);
-
-            // 処理完了後の遷移処理
-            router.push(`/record/${result.transcript_id}`);
-        } catch (error) {
-            console.error('録音の保存に失敗しました:', error);
-            alert('録音の保存に失敗しました。もう一度お試しください。');
-        } finally {
-            setIsUploading(false);
-        }
-    };
-
-    useEffect(() => {
-        return () => {
-            if (mediaRecorderRef.current && isRecording) {
-                mediaRecorderRef.current.stop();
-            }
-        };
-    }, [isRecording]);
-
-    return (
-        <div className="flex min-h-screen flex-col items-center justify-start bg-gradient-to-br from-purple-50 via-pink-50 to-blue-50 p-4">
-            {/* ヘッダー */}
-            <header className="w-full max-w-xl flex justify-between items-center mb-4">
-                <Link
-                    href="/children"
-                    className="flex items-center text-gray-600 hover:text-gray-800 transition-colors"
-                >
-                    <XCircle className="h-5 w-5 sm:h-6 sm:w-6 mr-1" />
-                    <span className="text-sm sm:text-base font-medium">やめる</span>
-                </Link>
-                <h1 className="flex-1 text-center text-lg font-bold text-gray-800 sm:text-xl">
-                    <span className="font-extrabold text-2xl sm:text-3xl">{childName}</span>ちゃん
-                    <br className="sm:hidden" />
-                    チャレンジ中！
-                </h1>
-                <div className="w-20 sm:w-24"></div>
-            </header>
-
-            {/* メインコンテンツ */}
-            <main className="flex flex-1 flex-col items-center justify-center w-full max-w-xl py-4">
-                {/* 録音ボタン */}
-                <div className="flex flex-col items-center">
-                    {!audioBlob && (
-                        <Button
-                            onClick={isRecording ? stopRecording : startRecording}
-                            className={cn(
-                                'w-40 h-40 sm:w-48 sm:h-48 rounded-full flex flex-col items-center justify-center shadow-xl transition-all duration-300',
-                                isRecording
-                                    ? 'bg-red-500 hover:bg-red-600 animate-pulse'
-                                    : 'bg-blue-400 hover:bg-blue-500'
-                            )}
-                            size="icon"
-                        >
-                            {isRecording ? (
-                                <>
-                                    <Mic className="h-16 w-16 sm:h-20 sm:w-20 text-white" />
-                                    <span className="mt-2 text-white text-base sm:text-lg font-semibold">
-                                        ストップ
-                                    </span>
-                                </>
-                            ) : (
-                                <>
-                                    <Mic className="h-16 w-16 sm:h-20 sm:w-20 text-white" />
-                                    <span className="mt-2 text-white text-base sm:text-lg font-semibold">
-                                        スタート
-                                    </span>
-                                </>
-                            )}
-                        </Button>
-                    )}
-
-                    {/* 保存する */}
-                    {audioBlob && (
-                        <Button
-                            onClick={saveRecording}
-                            disabled={isUploading}
-                            className={cn(
-                                'py-3 mt-8 text-lg font-semibold rounded-full shadow-md w-40',
-                                isUploading
-                                    ? 'bg-gray-400 text-gray-600 cursor-not-allowed' // 送信中：グレーで無効化
-                                    : 'bg-green-500 text-white hover:bg-green-600 hover:scale-105'
-                            )}
-                        >
-                            {isUploading ? ( // ←条件分岐：送信中は異なる表示
-                                <>
-                                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
-                                    まっててね...
-                                </>
-                            ) : (
-                                <>
-                                    <Save className="mr-2 h-5 w-5" />
-                                    保存する
-                                </>
-                            )}
-                        </Button>
-                    )}
-                </div>
-
-                {/* フレーズボタン */}
-                <div className="flex flex-col sm:flex-row gap-4 w-full max-w-xs mt-12">
-                    <Button
-                        onClick={() => setShowMamaPhraseDialog(true)}
-                        className="flex-1 py-3 text-sm sm:text-base font-semibold rounded-full shadow-md transition-transform transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-400 bg-purple-300 text-white hover:bg-purple-400"
-                    >
-                        <Volume2 className="mr-2 h-4 w-4" />
-                        おねがい
-                    </Button>
-                    <Button
-                        onClick={() => setShowChildPhraseDialog(true)}
-                        className="flex-1 py-3 text-sm sm:text-base font-semibold rounded-full shadow-md transition-transform transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-400 bg-yellow-300 text-white hover:bg-yellow-400"
-                    >
-                        <HelpCircle className="mr-2 h-4 w-4" />
-                        たすけて
-                    </Button>
-                </div>
-            </main>
-
-            {/* ママ用フレーズダイアログ */}
-            <Dialog open={showMamaPhraseDialog} onOpenChange={setShowMamaPhraseDialog}>
-                <DialogContent className="sm:max-w-[425px] rounded-xl p-6">
-                    <DialogHeader>
-                        <DialogTitle className="text-xl font-bold text-gray-800">おねがいフレーズ</DialogTitle>
-                        <DialogDescription className="text-gray-600 text-sm">
-                            外国の方に話しかける前に使えます。
-                        </DialogDescription>
-                    </DialogHeader>
-                    <div className="mt-4 space-y-3 text-lg text-gray-700">
-                        <p className="font-semibold">Hello! Excuse me, my child is learning English.</p>
-                        <p className="text-sm text-gray-500">（すみません。子供が英語を勉強しています。）</p>
-                        <p className="font-semibold">Would you mind speaking a little with my child?</p>
-                        <p className="text-sm text-gray-500">（少しお話しできますか？）</p>
-                    </div>
-                    <Button
-                        onClick={() => setShowMamaPhraseDialog(false)}
-                        className="mt-6 w-full rounded-full bg-blue-400 hover:bg-blue-500 text-white"
-                    >
-                        もどる
-                    </Button>
-                </DialogContent>
-            </Dialog>
-
-            {/* 子ども用フレーズダイアログ */}
-            <Dialog open={showChildPhraseDialog} onOpenChange={setShowChildPhraseDialog}>
-                <DialogContent className="sm:max-w-[425px] rounded-xl p-6">
-                    <DialogHeader>
-                        <DialogTitle className="text-xl font-bold text-gray-800">おたすけフレーズ</DialogTitle>
-                        <DialogDescription className="text-gray-600 text-sm">
-                            こまったときに、これをつかってみよう！
-                        </DialogDescription>
-                    </DialogHeader>
-                    <div className="mt-4 space-y-3 text-lg text-gray-700">
-                        <p className="font-semibold">Again, please.</p>
-                        <p className="text-sm text-gray-500">（もう一回いって）</p>
-                        <p className="font-semibold">Slowly, please.</p>
-                        <p className="text-sm text-gray-500">（ゆっくりいって）</p>
-                        <p className="font-semibold">Sorry, I don’t understand.</p>
-                        <p className="text-sm text-gray-500">（ごめんね、わからなかった）</p>
-                        <p className="font-semibold">Thank you! Bye-bye.</p>
-                        <p className="text-sm text-gray-500">（ありがとう！バイバイ。）</p>
-                    </div>
-                    <Button
-                        onClick={() => setShowChildPhraseDialog(false)}
-                        className="mt-6 w-full rounded-full bg-blue-400 hover:bg-blue-500 text-white"
-                    >
-                        とじる
-                    </Button>
-                </DialogContent>
-            </Dialog>
+          {/* 保存する */}
+          {audioBlob && (
+            <Button
+              onClick={saveRecording}
+              disabled={isUploading}
+              className={cn(
+                'py-3 mt-8 text-lg font-semibold rounded-full shadow-md w-40',
+                isUploading
+                  ? 'bg-gray-400 text-gray-600 cursor-not-allowed' // 送信中：グレーで無効化
+                  : 'bg-green-500 text-white hover:bg-green-600 hover:scale-105'
+              )}
+            >
+              {isUploading ? ( // ←条件分岐：送信中は異なる表示
+                <>
+                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
+                  まっててね...
+                </>
+              ) : (
+                <>
+                  <Save className="mr-2 h-5 w-5" />
+                  保存する
+                </>
+              )}
+            </Button>
+          )}
         </div>
-    );
+
+        {/* フレーズボタン */}
+        <div className="flex flex-col sm:flex-row gap-4 w-full max-w-xs mt-12">
+          <Button
+            onClick={() => setShowMamaPhraseDialog(true)}
+            className="flex-1 py-3 text-sm sm:text-base font-semibold rounded-full shadow-md transition-transform transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-400 bg-purple-300 text-white hover:bg-purple-400"
+          >
+            <Volume2 className="mr-2 h-4 w-4" />
+            おねがい
+          </Button>
+          <Button
+            onClick={() => setShowChildPhraseDialog(true)}
+            className="flex-1 py-3 text-sm sm:text-base font-semibold rounded-full shadow-md transition-transform transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-400 bg-yellow-300 text-white hover:bg-yellow-400"
+          >
+            <HelpCircle className="mr-2 h-4 w-4" />
+            たすけて
+          </Button>
+        </div>
+      </main>
+
+      {/* ママ用フレーズダイアログ */}
+      <Dialog open={showMamaPhraseDialog} onOpenChange={setShowMamaPhraseDialog}>
+        <DialogContent className="sm:max-w-[425px] rounded-xl p-6">
+          <DialogHeader>
+            <DialogTitle className="text-xl font-bold text-gray-800">おねがいフレーズ</DialogTitle>
+            <DialogDescription className="text-gray-600 text-sm">
+              外国の方に話しかける前に使えます。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-4 space-y-3 text-lg text-gray-700">
+            <p className="font-semibold">Hello! Excuse me, my child is learning English.</p>
+            <p className="text-sm text-gray-500">（すみません。子供が英語を勉強しています。）</p>
+            <p className="font-semibold">Would you mind speaking a little with my child?</p>
+            <p className="text-sm text-gray-500">（少しお話しできますか？）</p>
+          </div>
+          <Button
+            onClick={() => setShowMamaPhraseDialog(false)}
+            className="mt-6 w-full rounded-full bg-blue-400 hover:bg-blue-500 text-white"
+          >
+            もどる
+          </Button>
+        </DialogContent>
+      </Dialog>
+
+      {/* 子ども用フレーズダイアログ */}
+      <Dialog open={showChildPhraseDialog} onOpenChange={setShowChildPhraseDialog}>
+        <DialogContent className="sm:max-w-[425px] rounded-xl p-6">
+          <DialogHeader>
+            <DialogTitle className="text-xl font-bold text-gray-800">おたすけフレーズ</DialogTitle>
+            <DialogDescription className="text-gray-600 text-sm">
+              こまったときに、これをつかってみよう！
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-4 space-y-3 text-lg text-gray-700">
+            <p className="font-semibold">Again, please.</p>
+            <p className="text-sm text-gray-500">（もう一回いって）</p>
+            <p className="font-semibold">Slowly, please.</p>
+            <p className="text-sm text-gray-500">（ゆっくりいって）</p>
+            <p className="font-semibold">Sorry, I don’t understand.</p>
+            <p className="text-sm text-gray-500">（ごめんね、わからなかった）</p>
+            <p className="font-semibold">Thank you! Bye-bye.</p>
+            <p className="text-sm text-gray-500">（ありがとう！バイバイ。）</p>
+          </div>
+          <Button
+            onClick={() => setShowChildPhraseDialog(false)}
+            className="mt-6 w-full rounded-full bg-blue-400 hover:bg-blue-500 text-white"
+          >
+            とじる
+          </Button>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
 }

--- a/frontend/src/components/ui/accordion.tsx
+++ b/frontend/src/components/ui/accordion.tsx
@@ -1,24 +1,20 @@
-﻿"use client"
+﻿'use client';
 
-import * as React from "react"
-import * as AccordionPrimitive from "@radix-ui/react-accordion"
-import { ChevronDown } from "lucide-react"
+import * as React from 'react';
+import * as AccordionPrimitive from '@radix-ui/react-accordion';
+import { ChevronDown } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Accordion = AccordionPrimitive.Root
+const Accordion = AccordionPrimitive.Root;
 
 const AccordionItem = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
 >(({ className, ...props }, ref) => (
-  <AccordionPrimitive.Item
-    ref={ref}
-    className={cn("border-b", className)}
-    {...props}
-  />
-))
-AccordionItem.displayName = "AccordionItem"
+  <AccordionPrimitive.Item ref={ref} className={cn('border-b', className)} {...props} />
+));
+AccordionItem.displayName = 'AccordionItem';
 
 const AccordionTrigger = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
@@ -28,7 +24,7 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        "flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-left [&[data-state=open]>svg]:rotate-180",
+        'flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-left [&[data-state=open]>svg]:rotate-180',
         className
       )}
       {...props}
@@ -37,8 +33,8 @@ const AccordionTrigger = React.forwardRef<
       <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
-))
-AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+));
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
 
 const AccordionContent = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Content>,
@@ -49,13 +45,9 @@ const AccordionContent = React.forwardRef<
     className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
     {...props}
   >
-    <div className={cn("pb-4 pt-0", className)}>{children}</div>
+    <div className={cn('pb-4 pt-0', className)}>{children}</div>
   </AccordionPrimitive.Content>
-))
-AccordionContent.displayName = AccordionPrimitive.Content.displayName
+));
+AccordionContent.displayName = AccordionPrimitive.Content.displayName;
 
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }
-
-
-
-
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -47,7 +47,3 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 Button.displayName = 'Button';
 
 export { Button, buttonVariants };
-
-
-
-

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -174,6 +174,4 @@ function CalendarDayButton({
   );
 }
 
-export { Calendar, CalendarDayButton }
-
-
+export { Calendar, CalendarDayButton };

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,80 +1,55 @@
-﻿import * as React from "react"
+﻿import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
-      className
-    )}
-    {...props}
-  />
-))
-Card.displayName = "Card"
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-xl border bg-card text-card-foreground shadow', className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = 'Card';
 
-const CardHeader = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
-    {...props}
-  />
-))
-CardHeader.displayName = "CardHeader"
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
 
-const CardTitle = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("font-semibold leading-none tracking-tight", className)}
-    {...props}
-  />
-))
-CardTitle.displayName = "CardTitle"
+const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  )
+);
+CardTitle.displayName = 'CardTitle';
 
-const CardDescription = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-CardDescription.displayName = "CardDescription"
+const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  )
+);
+CardDescription.displayName = 'CardDescription';
 
-const CardContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
-CardContent.displayName = "CardContent"
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  )
+);
+CardContent.displayName = 'CardContent';
 
-const CardFooter = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
-    {...props}
-  />
-))
-CardFooter.displayName = "CardFooter"
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  )
+);
+CardFooter.displayName = 'CardFooter';
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
-
-
-
-
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,18 +1,18 @@
-﻿"use client"
+﻿'use client';
 
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Dialog = DialogPrimitive.Root
+const Dialog = DialogPrimitive.Root;
 
-const DialogTrigger = DialogPrimitive.Trigger
+const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = DialogPrimitive.Portal
+const DialogPortal = DialogPrimitive.Portal;
 
-const DialogClose = DialogPrimitive.Close
+const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -21,13 +21,13 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
     {...props}
   />
-))
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className
       )}
       {...props}
@@ -50,36 +50,21 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-))
-DialogContent.displayName = DialogPrimitive.Content.displayName
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-const DialogHeader = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
-      className
-    )}
+    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
     {...props}
   />
-)
-DialogHeader.displayName = "DialogHeader"
-
-const DialogFooter = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
-)
-DialogFooter.displayName = "DialogFooter"
+);
+DialogFooter.displayName = 'DialogFooter';
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -87,14 +72,11 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
-      className
-    )}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
     {...props}
   />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
@@ -102,11 +84,11 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
-))
-DialogDescription.displayName = DialogPrimitive.Description.displayName
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
@@ -119,8 +101,4 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
-}
-
-
-
-
+};

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,26 +1,22 @@
-﻿import * as React from "react"
+﻿import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
   ({ className, type, ...props }, ref) => {
     return (
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className
         )}
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Input.displayName = "Input"
+);
+Input.displayName = 'Input';
 
-export { Input }
-
-
-
-
+export { Input };

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,30 +1,21 @@
-﻿"use client"
+﻿'use client';
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-)
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+);
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
-    ref={ref}
-    className={cn(labelVariants(), className)}
-    {...props}
-  />
-))
-Label.displayName = LabelPrimitive.Root.displayName
+  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
 
-export { Label }
-
-
-
-
+export { Label };

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,37 +1,33 @@
-﻿"use client"
+﻿'use client';
 
-import * as React from "react"
-import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Popover = PopoverPrimitive.Root
+const Popover = PopoverPrimitive.Root;
 
-const PopoverTrigger = PopoverPrimitive.Trigger
+const PopoverTrigger = PopoverPrimitive.Trigger;
 
-const PopoverAnchor = PopoverPrimitive.Anchor
+const PopoverAnchor = PopoverPrimitive.Anchor;
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
+        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]',
         className
       )}
       {...props}
     />
   </PopoverPrimitive.Portal>
-))
-PopoverContent.displayName = PopoverPrimitive.Content.displayName
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }
-
-
-
-
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,16 +1,16 @@
-﻿"use client"
+﻿'use client';
 
-import * as React from "react"
-import * as SelectPrimitive from "@radix-ui/react-select"
-import { Check, ChevronDown, ChevronUp } from "lucide-react"
+import * as React from 'react';
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { Check, ChevronDown, ChevronUp } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Select = SelectPrimitive.Root
+const Select = SelectPrimitive.Root;
 
-const SelectGroup = SelectPrimitive.Group
+const SelectGroup = SelectPrimitive.Group;
 
-const SelectValue = SelectPrimitive.Value
+const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      'flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className
     )}
     {...props}
@@ -29,8 +29,8 @@ const SelectTrigger = React.forwardRef<
       <ChevronDown className="h-4 w-4 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
-))
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
 const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
@@ -38,16 +38,13 @@ const SelectScrollUpButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollUpButton
     ref={ref}
-    className={cn(
-      "flex cursor-default items-center justify-center py-1",
-      className
-    )}
+    className={cn('flex cursor-default items-center justify-center py-1', className)}
     {...props}
   >
     <ChevronUp className="h-4 w-4" />
   </SelectPrimitive.ScrollUpButton>
-))
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
 const SelectScrollDownButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
@@ -55,29 +52,25 @@ const SelectScrollDownButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollDownButton
     ref={ref}
-    className={cn(
-      "flex cursor-default items-center justify-center py-1",
-      className
-    )}
+    className={cn('flex cursor-default items-center justify-center py-1', className)}
     {...props}
   >
     <ChevronDown className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
-))
-SelectScrollDownButton.displayName =
-  SelectPrimitive.ScrollDownButton.displayName
+));
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
+>(({ className, children, position = 'popper', ...props }, ref) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
-        position === "popper" &&
-          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]',
+        position === 'popper' &&
+          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className
       )}
       position={position}
@@ -86,9 +79,9 @@ const SelectContent = React.forwardRef<
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(
-          "p-1",
-          position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+          'p-1',
+          position === 'popper' &&
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
         )}
       >
         {children}
@@ -96,8 +89,8 @@ const SelectContent = React.forwardRef<
       <SelectScrollDownButton />
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
-))
-SelectContent.displayName = SelectPrimitive.Content.displayName
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
@@ -105,11 +98,11 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    className={cn('px-2 py-1.5 text-sm font-semibold', className)}
     {...props}
   />
-))
-SelectLabel.displayName = SelectPrimitive.Label.displayName
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
@@ -118,7 +111,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}
@@ -130,8 +123,8 @@ const SelectItem = React.forwardRef<
     </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
-))
-SelectItem.displayName = SelectPrimitive.Item.displayName
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
@@ -139,11 +132,11 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
     {...props}
   />
-))
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export {
   Select,
@@ -156,8 +149,4 @@ export {
   SelectSeparator,
   SelectScrollUpButton,
   SelectScrollDownButton,
-}
-
-
-
-
+};

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -52,7 +52,3 @@ export function useAuth() {
     isAuthenticated: !!user,
   };
 }
-
-
-
-

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -22,7 +22,3 @@ export const auth = getAuth(app);
 export const analytics = typeof window !== 'undefined' ? getAnalytics(app) : null;
 
 export default app;
-
-
-
-

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,7 +4,3 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
-
-
-
-

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -19,4 +19,3 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
-

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,37 +1,37 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
-    darkMode: ['class'],
-    content: ['./src/app/**/*.{ts,tsx,js,jsx,mdx}', './src/components/**/*.{ts,tsx,js,jsx,mdx}'],
+  darkMode: ['class'],
+  content: ['./src/app/**/*.{ts,tsx,js,jsx,mdx}', './src/components/**/*.{ts,tsx,js,jsx,mdx}'],
   theme: {
-  	extend: {
-  		colors: {
-  			background: 'var(--background)',
-  			foreground: 'var(--foreground)'
-  		},
-  		keyframes: {
-  			'accordion-down': {
-  				from: {
-  					height: '0'
-  				},
-  				to: {
-  					height: 'var(--radix-accordion-content-height)'
-  				}
-  			},
-  			'accordion-up': {
-  				from: {
-  					height: 'var(--radix-accordion-content-height)'
-  				},
-  				to: {
-  					height: '0'
-  				}
-  			}
-  		},
-  		animation: {
-  			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
-  		}
-  	}
+    extend: {
+      colors: {
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+      },
+      keyframes: {
+        'accordion-down': {
+          from: {
+            height: '0',
+          },
+          to: {
+            height: 'var(--radix-accordion-content-height)',
+          },
+        },
+        'accordion-up': {
+          from: {
+            height: 'var(--radix-accordion-content-height)',
+          },
+          to: {
+            height: '0',
+          },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## 📝 やったこと

フロント部分のコードを Prettier で整形
src/app/(app)/history 配下のページファイル
frontend/src/app/(app)/record/[recordId]/page.tsx など
不要な空白・インデント・改行のズレを修正
CI でのフォーマットチェックに対応


## 🔗 関連 Issue

close #

## 📸 スクショ


## ✅ チェックリスト

- [ ] 動作確認した
- [ ] エラーが出ない
- [ ] スマホでも確認した（画面系の場合）

## 💭 補足・相談

今回はフロントのみ整形
全体整形はチーム作業が落ち着いた後にまとめて行う予定

## 🚀 マージ後にやること

チーム全員が develop を pull して整形済みコードを取得
後日、全体整形PRを作成予定
