### PR TITLE
BE-014: 認証APIテスト実装とFE-018: ログイン画面アクセシビリティ対応

### DIFF
--- a/backend/alembic/versions/2025_08_15_0133-810810cd45c9_add_firebase_uid_to_users_table.py
+++ b/backend/alembic/versions/2025_08_15_0133-810810cd45c9_add_firebase_uid_to_users_table.py
@@ -18,13 +18,13 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    """Upgrade schema."""
-    # firebase_uid column already exists from manual SQL
-    # This is a no-op migration for team sync
-    pass
+   """Upgrade schema: add firebase_uid column to users table"""
+   op.add_column(
+        'users',
+        sa.Column('firebase_uid', sa.String(), unique=True, nullable=True)
+    )
 
 
 def downgrade() -> None:
-    """Downgrade schema."""
-    # This migration doesn't change anything
-    pass
+    """Downgrade schema: remove firebase_uid column from users table"""
+    op.drop_column('users', 'firebase_uid')

--- a/backend/app/api/routers/auth.py
+++ b/backend/app/api/routers/auth.py
@@ -3,7 +3,7 @@ from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pydantic import BaseModel
 from datetime import datetime, timedelta
 from typing import Optional
-import jwt
+import jwt 
 from passlib.context import CryptContext
 from app.core.config import settings
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    """テスト用のクライアントを作成"""
+    return TestClient(app)
+
+@pytest.fixture
+def firebase_token():
+    """テスト用のダミー Firebase トークン"""
+    return "dummy_token"
+
+
+@pytest.fixture(autouse=True)
+def mock_verify_firebase_token(monkeypatch):
+    async def mock(token: str):
+        return {"uid": "test_uid", "email": "test@example.com", "name": "Test User"}
+    monkeypatch.setattr("app.main.verify_firebase_token", mock)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,20 @@
+import pytest
+from fastapi import status
+
+# --- テスト用の関数ベースでシンプルに書く ---
+
+def test_firebase_login_success(client, firebase_token):
+    """Firebase認証で正常にログインできるテスト"""
+    response = client.post("/api/auth/login", json={"idToken": firebase_token})
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()
+    assert "user" in data
+    assert data["user"]["email"] == "test@example.com"
+    assert data["user"]["firebase_uid"] == "test_uid"
+
+
+def test_firebase_login_missing_token(client):
+    """idTokenがない場合に422が返るテスト"""
+    response = client.post("/api/auth/login", json={})
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -67,7 +67,7 @@ export default function Home() {
   if (loading || backendLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100">
-        <div className="animate-pulse text-xl">
+        <div className="animate-pulse text-xl" aria-busy={loading || backendLoading} role="status">
           {loading ? '🔄 認証状態を確認中...' : '🔗 バックエンドと連携中...'}
         </div>
       </div>
@@ -94,6 +94,7 @@ export default function Home() {
           <button
             onClick={handleGoogleLogin}
             disabled={backendLoading}
+            aria-label="Googleでログイン"
             className="w-full bg-blue-500 hover:bg-blue-600 disabled:bg-blue-300 text-white font-bold py-3 px-4 rounded-lg transition-colors flex items-center justify-center gap-2"
           >
             {backendLoading ? (
@@ -103,7 +104,7 @@ export default function Home() {
               </>
             ) : (
               <>
-                <svg className="w-5 h-5" viewBox="0 0 24 24">
+                <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
                   <path
                     fill="currentColor"
                     d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"


### PR DESCRIPTION
## 📝 やったこと

BE-014: 認証APIテスト実装
FE-018: ログイン画面アクセシビリティ対応

firebase_uidのカラム追加

## 🔗 関連 Issue

close #55
close #92

## 📸 スクショ


## ✅ チェックリスト

- [ ] 動作確認した
- [ ] エラーが出ない
- [ ] スマホでも確認した（画面系の場合）

## 💭 補足・相談
git pull origin develop
docker-compose down -v && docker-compose up -d
docker-compose exec backend alembic upgrade head
してください！

## 🚀 マージ後にやること

FE-019: ログイン画面テスト実装をする
