### PR TITLE
fix: child_idをクエリパラメータとして送信するよう修正

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -283,17 +283,32 @@ export const api = {
     },
   },
 
-  // 音声文字起こしAPI
+  // 🎤 音声文字起こしAPI
   voice: {
+    // 音声ファイルを文字起こしするAPI（修正版：child_idをクエリパラメータとして送信）
     transcribe: async (audioBlob: Blob, childId: string) => {
       try {
+        console.log('🎤 音声文字起こし開始:', { childId, blobSize: audioBlob.size });
+        
+        // childIdが存在することを確認
+        if (!childId) {
+          throw new Error('child_idが指定されていません');
+        }
+        
+        // 認証ヘッダーを取得（Content-Typeは削除してFormDataに任せる）
         const headers = await getAuthHeaders();
         delete headers['Content-Type'];
+
+        // FormDataを作成して音声ファイルを追加
         const formData = new FormData();
         formData.append('file', audioBlob, 'recording.webm');
-        formData.append('child_id', childId);
 
-        const res = await fetch(`${API_URL}/api/voice/transcribe`, {
+        // child_idをクエリパラメータとして確実に追加
+        const url = `${API_URL}/api/voice/transcribe?child_id=${encodeURIComponent(childId)}`;
+        console.log('🎤 リクエストURL:', url);
+        console.log('🎤 child_id:', childId);
+
+        const res = await fetch(url, {
           method: 'POST',
           headers: {
             ...headers,
@@ -301,15 +316,19 @@ export const api = {
           body: formData,
         });
 
+        console.log('🎤 レスポンス受信:', res.status, res.statusText);
+
         if (!res.ok) {
           const errorData = await res.json();
-          console.error('バックエンドエラー詳細:', errorData);
+          console.error('❌ 文字起こしエラー詳細:', errorData);
           throw new Error(errorData.detail || `文字起こしに失敗しました(${res.status})`);
         }
 
-        return res.json();
+        const result = await res.json();
+        console.log('✅ 文字起こし成功:', result);
+        return result;
       } catch (error) {
-        console.error('文字起こしに失敗:', error);
+        console.error('❌ 文字起こしに失敗:', error);
         throw error;
       }
     },
@@ -355,7 +374,7 @@ export const api = {
     },
   },
 
-  // 会話履歴API
+  // 💬 会話履歴API
   conversations: {
     list: async (childId?: string) => {
       try {
@@ -402,7 +421,7 @@ export const api = {
     },
   },
 
-  // AIフィードバックAPI
+  // 🤖 AIフィードバックAPI
   feedback: {
     generate: async (transcriptId: string) => {
       try {


### PR DESCRIPTION
## 📝 やったこと

音声録音機能で発生していた422エラー（Unprocessable Entity）を修正しました。
サーバーが要求する`child_id`パラメータを正しい形式で送信するように変更。

### 具体的な修正内容
- `api.ts`の`voice.transcribe`関数を修正
- `child_id`をFormDataではなく、クエリパラメータとして送信するように変更
- エラーハンドリングとデバッグログを強化

### 修正前（エラー発生）
- 422 Unprocessable Entity エラー
- 「録音の保存に失敗しました」メッセージ

### 修正後（正常動作）
- 録音→保存が正常に完了
- 次のページに遷移

## ✅ チェックリスト

- [x] 動作確認した
- [x] エラーが出ない
- [ ] スマホでも確認した（画面系の場合）

## 💭 補足・相談

### 問題の原因
サーバー側のAPIが`child_id`を**クエリパラメータ**として期待していたのに、
フロントエンドでは**FormData**として送信していたため、422エラーが発生していました。

### 修正のポイント
```typescript
// 修正前：FormDataで送信
formData.append('child_id', childId);

// 修正後：クエリパラメータで送信
const url = `${API_URL}/api/voice/transcribe?child_id=${encodeURIComponent(childId)}`;
```

### レビューで特に見てほしい点
- encodeURIComponent()を使ったURL エスケープ処理
- エラーハンドリングの改善
- デバッグログの追加

### 残っている課題
録音保存後のページで子ども情報取得が404エラーになる問題がありますが、 
これは別で対応予定です。

## 🚀 マージ後にやること
特になし（環境変数の変更等は不要）

## 次のタスク
- 子ども情報取得の404エラー修正
- スマホでの動作確認
