### PR TITLE
fix: 子ども管理ページの型エラーを修正

### DIFF
--- a/frontend/src/app/(app)/children/page.tsx
+++ b/frontend/src/app/(app)/children/page.tsx
@@ -20,7 +20,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 interface Child {
-  id: number;
+  id: string;
   name: string;
   age: number;
 }
@@ -71,10 +71,10 @@ export default function ChildrenPage() {
   useEffect(() => {
     if (apiChildren) {
       const transformedChildren = apiChildren.map((child) => ({
-        id: child.id,
+        id: child.id.toString(), // string変換を追加
         name: child.nickname || child.name,
-        age: child.birth_date
-          ? new Date().getFullYear() - new Date(child.birth_date).getFullYear()
+        age: child.birthdate // birth_date → birthdate に修正
+          ? new Date().getFullYear() - new Date(child.birthdate).getFullYear()
           : 0,
       }));
       setChildren(transformedChildren);
@@ -103,7 +103,7 @@ export default function ChildrenPage() {
   const addChild = () => {
     if (newChild.name && newChild.age) {
       const child: Child = {
-        id: Date.now(),
+        id: Date.now().toString(), // .toString()を追加
         name: newChild.name,
         age: parseInt(newChild.age),
       };
@@ -126,7 +126,7 @@ export default function ChildrenPage() {
     }
   };
 
-  const deleteChild = (id: number) => {
+  const deleteChild = (id: string) => {
     setChildren(children.filter((child) => child.id !== id));
   };
 


### PR DESCRIPTION


## 📝 やったこと

- Child interfaceのidをstringに変更
- API連携でのid型変換を追加
- birth_date → birthdateプロパティ名修正
- addChild/deleteChild関数の型整合性修正

## 🔗 関連 Issue

<!-- 下の行の#の後に番号を書くと自動でIssueが閉じます -->

close #

## 📸 スクショ

<!-- 画面の変更があれば画像を貼る（ドラッグ&ドロップでOK） -->

## ✅ チェックリスト

- [ ] 動作確認した
- [ ] エラーが出ない
- [ ] スマホでも確認した（画面系の場合）

## 💭 補足・相談

<!--
例：
- ○○の部分で迷いました
- ××はこういう理由でこうしました
- レビューで特に見てほしい：△△の部分
-->

## 🚀 マージ後にやること

<!-- あれば書く（例：環境変数の設定が必要） -->
