### PR TITLE
サンプルデータ移行と詳細ページ表示機能を実装

### DIFF
--- a/backend/app/api/voice/transcription.py
+++ b/backend/app/api/voice/transcription.py
@@ -147,3 +147,35 @@ async def get_voice_history(child_id: str, db: AsyncSession = Depends(get_async_
             for challenge in challenges
         ]
     }
+
+@router.get("/challenge/{challenge_id}")
+async def get_challenge_detail(challenge_id: str, db: AsyncSession = Depends(get_async_db)):
+    """個別のチャレンジ詳細を取得"""
+    try:
+        print(f"🔍 チャレンジ詳細取得開始: challenge_id={challenge_id}")
+        
+        # UUID変換して非同期クエリ実行
+        challenge_uuid = UUID(challenge_id)
+        result = await db.execute(select(Challenge).where(Challenge.id == challenge_uuid))
+        challenge = result.scalars().first()
+        
+        if not challenge:
+            print(f"❌ チャレンジが見つかりません: {challenge_id}")
+            raise HTTPException(status_code=404, detail="チャレンジが見つかりません")
+        
+        print(f"✅ チャレンジ詳細取得成功: {challenge_id}")
+        
+        return {
+            "id": str(challenge.id),
+            "child_id": str(challenge.child_id),
+            "transcript": challenge.transcript,
+            "comment": challenge.comment,
+            "created_at": challenge.created_at,
+            "status": "completed" if challenge.transcript else "processing"
+        }
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"❌ チャレンジ詳細取得エラー: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"チャレンジ詳細取得エラー: {str(e)}")

--- a/frontend/src/app/(app)/history/[childId]/[recordId]/page.tsx
+++ b/frontend/src/app/(app)/history/[childId]/[recordId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { api } from '@/lib/api';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import { ArrowLeft } from 'lucide-react';
@@ -43,8 +44,8 @@ export default function ChallengeDetailPage() {
         setLoading(true);
         setError(null);
 
-        // 音声認識結果をAPIから取得
-        const data = await api.voice.getTranscript(recordId);
+        // 個別チャレンジの詳細データをAPIから取得
+        const data = await api.voice.getChallenge(recordId);
 
         // child_idが一致するかチェック
         if (data.child_id !== childId) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -372,6 +372,26 @@ export const api = {
         throw error;
       }
     },
+
+    getChallenge: async (challengeId: string) => {
+      try {
+        const headers = await getAuthHeaders();
+        const res = await fetch(`${API_URL}/api/voice/challenge/${challengeId}`, {
+          method: 'GET',
+          headers,
+        });
+    
+        if (!res.ok) {
+          const errorData = await res.json();
+          throw new Error(errorData.detail || 'チャレンジ詳細の取得に失敗しました');
+        }
+    
+        return res.json();
+      } catch (error) {
+        console.error('チャレンジ詳細の取得に失敗:', error);
+        throw error;
+      }
+    },
   },
 
   // 💬 会話履歴API


### PR DESCRIPTION
## 📝 やったこと

サンプルデータ移行と詳細ページ表示機能を実装しました

### 1. サンプルデータ移行
- 新しいテスト用アカウント `bud.2506.mse@gmail.com` を作成
- Firebase Authenticationでアカウント登録完了
- あかりちゃん・そらちゃんのサンプルデータを新アカウントに移行

### 2. 詳細ページ表示機能実装
- **バックエンド**: 個別チャレンジ取得API (`/api/voice/challenge/{challenge_id}`) を追加
- **フロントエンド**: 詳細ページのAPI連携を修正・完成
- **動作確認**: 文字起こし・AIフィードバックが正常に表示されることを確認


## 📊 移行したサンプルデータ詳細

| 子供名 | チャレンジ数 | 移行先アカウント |
|--------|-------------|-----------------|
| あかりちゃん | 2件 | bud.2506.mse@gmail.com |
| そらちゃん | 2件 | bud.2506.mse@gmail.com |
| ゆうくん | 4件 | 今回は移行せずそのまま |


## 🔧 技術的な実装内容

### バックエンド
```python
# 新しいAPIエンドポイント追加
@router.get("/challenge/{challenge_id}")
async def get_challenge_detail(challenge_id: str, db: AsyncSession = Depends(get_async_db)):
    # 個別のチャレンジ詳細を取得する処理
    # UUID変換、データベース検索、エラーハンドリングを実装
```
### フロントエンド
- api.ts に getChallenge 関数を追加
- 詳細ページ ([recordId]/page.tsx) のAPI呼び出しを修正
- api.voice.getTranscript → api.voice.getChallenge に変更
- インポート文の追加とエラーハンドリングの実装

### データベース操作
```python
-- 実行したデータ移行SQL
UPDATE children 
SET user_id = '1b474d9f-e1bf-4dca-a30f-7b44d725a5a7' 
WHERE nickname IN ('あかりちゃん', 'そらちゃん');
```

## 📸 スクショ
<img width="844" height="283" alt="スクリーンショット 2025-08-19 16 02 21" src="https://github.com/user-attachments/assets/3fc005be-3e65-4221-8818-01fcdafda96d" />
<img width="606" height="245" alt="スクリーンショット 2025-08-19 16 02 09" src="https://github.com/user-attachments/assets/71246602-ef92-4e4f-a632-aa31fcc5790d" />
<img width="307" height="496" alt="スクリーンショット 2025-08-19 20 51 20" src="https://github.com/user-attachments/assets/795ae79b-09a3-4991-8b58-6c0b9a1ef6aa" />
<img width="298" height="551" alt="スクリーンショット 2025-08-19 21 14 40" src="https://github.com/user-attachments/assets/acd9a203-8618-4048-acf5-92633f39262e" />


## ✅ 動作確認方法

1. `bud.2506.mse@gmail.com` でログイン
2. あかりちゃんまたはそらちゃんを選択
3. 履歴一覧から詳細ページに遷移
4. 以下が正常に表示されることを確認：
   - **話したこと**: 文字起こし結果
   - **AIフィードバック**: 褒め言葉とアドバイス
   - **日時**: チャレンジ実施日時

### 確認済み項目
- [x] 動作確認した
- [x] エラーが出ない
- [ ] スマホでも確認した（画面系の場合）

## 🎪 今回の作業の意義

- **データベース → ブラウザ表示の流れ**が完全に動作することを証明
- 実際のユーザーアカウントでサンプルデータをテスト可能
- Whisper API権限解決後、すぐに本格運用可能な状態を構築
- 個別チャレンジ詳細取得機能により、履歴管理機能が完成

## 💭 補足・相談

**技術的な実装詳細：**
- **データ移行**: SQLで2人の子供データを新アカウントに紐付け（UPDATE文実行）
- **バックエンド**: 既存の `/history/{child_id}` とは別に、個別記録用の `/challenge/{challenge_id}` エンドポイントを追加
- **フロントエンド**: APIインポートエラーを解決し、正しいエンドポイント呼び出しに修正

**動作確認済み：**
- 新アカウントでのログイン・認証
- 移行されたデータの表示
- 詳細ページでの文字起こし・AIフィードバック表示
- エラーハンドリングとローディング状態

**レビューで特に見てほしい：**
- バックエンドAPIのエラーハンドリング部分
- フロントエンドのAPI呼び出し修正が適切か
- データベース操作の安全性

## 🚀 次のステップ（マージ後にやること）

1. **OpenAI Whisper APIの権限問題解決**（講師に確認中）
2. **ゆうくんのサンプルデータを利用したAIフィードバック生成テスト**
3. **月間チャレンジ回数カウント機能の実装**
4. **新規音声録音 → 文字起こし → AIフィードバックの完全な流れのテスト**

**環境変数・設定変更：** なし  
**データベース変更：** 既存データの移行のみ（スキーマ変更なし）