### PR TITLE
feat: 本番環境設定追加とデバッグモード削除

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,0 +1,12 @@
+FROM python:3.11-alpine
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/models/child.py
+++ b/backend/app/models/child.py
@@ -11,7 +11,7 @@ class Child(Base):
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     nickname = Column(String(50))
-    birth_date = Column(Date)
+    birthdate = Column(Date) # birth_date → birthdate に変更
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,0 +1,63 @@
+services:
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.prod
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+      - NEXT_PUBLIC_ENV=production
+    depends_on:
+      - backend
+    networks:
+      - app-network
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.prod
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./serviceAccountKey.json:/app/serviceAccountKey.json:ro
+    env_file:
+      - ./backend/.env
+    environment:
+      - PYTHONPATH=/app
+      - PYTHONUNBUFFERED=1
+    depends_on:
+      - db
+    networks:
+      - app-network
+
+  db:
+    image: postgres:15-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-bud_user}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-bud_password}
+      - POSTGRES_DB=${POSTGRES_DB:-bud_db}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./backend/database/init.sql:/docker-entrypoint-initdb.d/init.sql
+    networks:
+      - app-network
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:-bud_user} -d ${POSTGRES_DB:-bud_db}",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+    driver: local
+
+networks:
+  app-network:
+    driver: bridge

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,0 +1,13 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --only=production
+
+COPY . .
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]

--- a/frontend/src/__tests__/pages/Children.test.tsx
+++ b/frontend/src/__tests__/pages/Children.test.tsx
@@ -26,7 +26,16 @@ vi.mock('@/lib/api', () => ({
 
 // Next.js Image コンポーネントのモック
 vi.mock('next/image', () => ({
-  default: ({ src, alt, ...props }: { src: string; alt: string; [key: string]: any }) => (
+  default: ({
+    src,
+    alt,
+    ...props
+  }: {
+    src: string;
+    alt: string;
+    [key: string]: string | number | boolean | undefined;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
     <img src={src} alt={alt} {...props} />
   ),
 }));

--- a/frontend/src/__tests__/pages/Login.test.tsx
+++ b/frontend/src/__tests__/pages/Login.test.tsx
@@ -12,7 +12,16 @@ vi.mock('@/hooks/useAuth');
 vi.mock('@/lib/api');
 vi.mock('firebase/auth');
 vi.mock('next/image', () => ({
-  default: ({ src, alt, ...props }: { src: string; alt: string; [key: string]: any }) => (
+  default: ({
+    src,
+    alt,
+    ...props
+  }: {
+    src: string;
+    alt: string;
+    [key: string]: string | number | boolean | undefined;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
     <img src={src} alt={alt} {...props} />
   ),
 }));


### PR DESCRIPTION
## 📝 やったこと

本番環境用のDocker設定を追加し、デバッグモード（左下のNマーク）を削除しました。
また、子ども登録・一覧取得のAPIエラーも修正しました。

## 📸 スクショ

### 修正前（開発モード）
- 左下にNマーク（デバッグモード表示）あり
- 子ども登録・一覧でエラー発生

### 修正後（本番モード）
- 左下のNマーク消去 ✅
- 子ども登録・一覧取得が正常動作 ✅

## ✅ チェックリスト

- [x] 動作確認した
- [x] エラーが出ない
- [x] スマホでも確認した（画面系の場合）

## 💭 補足・相談

### 追加したファイル
- `frontend/Dockerfile.prod` - フロントエンド本番用Docker設定
- `backend/Dockerfile.prod` - バックエンド本番用Docker設定
- `compose.prod.yml` - 本番環境用のDocker Compose設定

### 修正したファイル
- `app/models/child.py` - データベースカラム名との整合性修正
- `src/__tests__/pages/Children.test.tsx` - TypeScriptエラー修正
- `src/__tests__/pages/Login.test.tsx` - TypeScriptエラー修正

### 迷った点・工夫した点
- データベースのカラム名（`birthdate`）とPythonモデル（`birth_date`）の不一致を発見
- データベースに合わせる方向で統一（より自然なため）
- 開発用と本番用の設定を分離して、使い分けできるようにしました

- **新規追加の3つのDockerファイル**の設定内容
- **`app/models/child.py`** のフィールド名変更（`birth_date` → `birthdate`）
- **開発フローの使い分け方法**が適切か
- **テストファイルのTypeScriptエラー修正**が適切か

### 使い分け方法
**日常開発**: `docker-compose up`（ホットリロード有効、Nマークあり）
**最終確認・デモ**: `docker-compose -f compose.prod.yml up --build`（本番品質、Nマークなし）

## 🚀 マージ後にやること
特になし（既存の開発環境に影響なし）
