### PR TITLE
feat: 文字起こしUIに改行＋マーキー表示を追加

### DIFF
--- a/frontend/src/app/(app)/challenge/[childId]/page.tsx
+++ b/frontend/src/app/(app)/challenge/[childId]/page.tsx
@@ -388,10 +388,15 @@ export default function ChallengePage() {
           {/* 文字起こし結果表示 */}
           {transcription && (
             <div className="w-full max-w-md mt-6 p-4 bg-white rounded-lg shadow-md">
-              <h3 className="text-lg font-semibold text-gray-800 mb-2">文字起こし結果</h3>
-              <div className="text-gray-700 bg-gray-50 p-3 rounded border max-h-60 overflow-y-auto whitespace-pre-line">
-                {transcription}
-              </div>
+               <h3 className="text-lg font-semibold text-gray-800 mb-2">文字起こし結果</h3>
+
+               <div className="space-y-2">
+                 {transcription.split('\n').map((line, index) => (
+                   <p key={index} className="text-gray-700 bg-gray-50 p-2 rounded border">
+                     {line}
+                   </p>
+                  ))}
+                </div>
               {/* 録音状態の説明追加 */}
               {isListening && (
                 <p className="text-sm text-blue-600 mt-2">

--- a/frontend/src/app/(app)/challenge/[childId]/page.tsx
+++ b/frontend/src/app/(app)/challenge/[childId]/page.tsx
@@ -388,23 +388,41 @@ export default function ChallengePage() {
           {/* 文字起こし結果表示 */}
           {transcription && (
             <div className="w-full max-w-md mt-6 p-4 bg-white rounded-lg shadow-md">
-               <h3 className="text-lg font-semibold text-gray-800 mb-2">文字起こし結果</h3>
+              <h3 className="text-lg font-semibold text-gray-800 mb-2">文字起こし結果</h3>
 
-               <div className="space-y-2">
-                 {transcription.split('\n').map((line, index) => (
-                   <p key={index} className="text-gray-700 bg-gray-50 p-2 rounded border">
+              <div className="space-y-2">
+                {transcription.split('\n').map((line, index) => {
+                  if (!line.trim()) return null; // 空行はスキップ
+
+                  // 1文字0.3秒、最低5秒（短すぎないようにする）
+                  const duration = Math.max(5, line.length * 0.3);
+
+                 return (
+                  <div
+                    key={index}
+                    className="relative overflow-hidden h-10 bg-gray-50 p-2 rounded border"
+                  >
+                    <p
+                       className="whitespace-nowrap"
+                       style={{
+                         animation: `marquee ${duration}s linear infinite`,
+                    }}
+                    >
                      {line}
-                   </p>
-                  ))}
+                  </p>
                 </div>
-              {/* 録音状態の説明追加 */}
-              {isListening && (
-                <p className="text-sm text-blue-600 mt-2">
-                  📍 まだ録音中です。「ストップ」を押すと終了します。
-                </p>
-              )}
-            </div>
-          )}
+               );
+             })}
+           </div>
+
+            {isListening && (
+              <p className="text-sm text-blue-600 mt-2">
+                📍 まだ録音中です。「ストップ」を押すと終了します。
+             </p>
+            )}
+          </div>
+        )}
+
 
           {/* 保存ボタン（録音完了後に表示） */}
           {transcription && !isListening && (

--- a/frontend/src/app/(app)/challenge/[childId]/page.tsx
+++ b/frontend/src/app/(app)/challenge/[childId]/page.tsx
@@ -388,41 +388,23 @@ export default function ChallengePage() {
           {/* 文字起こし結果表示 */}
           {transcription && (
             <div className="w-full max-w-md mt-6 p-4 bg-white rounded-lg shadow-md">
-              <h3 className="text-lg font-semibold text-gray-800 mb-2">文字起こし結果</h3>
+               <h3 className="text-lg font-semibold text-gray-800 mb-2">文字起こし結果</h3>
 
-              <div className="space-y-2">
-                {transcription.split('\n').map((line, index) => {
-                  if (!line.trim()) return null; // 空行はスキップ
-
-                  // 1文字0.3秒、最低5秒（短すぎないようにする）
-                  const duration = Math.max(5, line.length * 0.3);
-
-                 return (
-                  <div
-                    key={index}
-                    className="relative overflow-hidden h-10 bg-gray-50 p-2 rounded border"
-                  >
-                    <p
-                       className="whitespace-nowrap"
-                       style={{
-                         animation: `marquee ${duration}s linear infinite`,
-                    }}
-                    >
+               <div className="space-y-2">
+                 {transcription.split('\n').map((line, index) => (
+                   <p key={index} className="text-gray-700 bg-gray-50 p-2 rounded border">
                      {line}
-                  </p>
+                   </p>
+                  ))}
                 </div>
-               );
-             })}
-           </div>
-
-            {isListening && (
-              <p className="text-sm text-blue-600 mt-2">
-                📍 まだ録音中です。「ストップ」を押すと終了します。
-             </p>
-            )}
-          </div>
-        )}
-
+              {/* 録音状態の説明追加 */}
+              {isListening && (
+                <p className="text-sm text-blue-600 mt-2">
+                  📍 まだ録音中です。「ストップ」を押すと終了します。
+                </p>
+              )}
+            </div>
+          )}
 
           {/* 保存ボタン（録音完了後に表示） */}
           {transcription && !isListening && (

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -26,13 +26,19 @@ const config: Config = {
             height: '0',
           },
         },
+        marquee: {                                  
+          '0%': { transform: 'translateX(-100%)' },   
+          '100%': { transform: 'translateX(100%)' },  
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
+        marquee: 'marquee 10s linear infinite',     
       },
     },
   },
   plugins: [],
 };
 export default config;
+

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -26,19 +26,13 @@ const config: Config = {
             height: '0',
           },
         },
-        marquee: {                                  
-          '0%': { transform: 'translateX(-100%)' },   
-          '100%': { transform: 'translateX(100%)' },  
-        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
-        marquee: 'marquee 10s linear infinite',     
       },
     },
   },
   plugins: [],
 };
 export default config;
-


### PR DESCRIPTION
## 📝 やったこと
  - 文字起こし結果を改行ごとに段落表示
  - Tailwind にカスタム `marquee` アニメーションを追加
  - 各行をマーキー表示（横スクロール）に変更
  - 行ごとに文字数に応じたスクロール速度を調整（1文字 ≒ 0.3秒、最低5秒）
  - 行ごとに背景・枠線を付与して読みやすさを改善

## 📸 スクショ

<!-- 画面の変更があれば画像を貼る（ドラッグ&ドロップでOK） -->

## ✅ チェックリスト
- [× ] スタートボタンで音声認識が開始される
- [× ] 録音中の文字起こしがリアルタイムで表示される
- [×] 改行ごとに段落が分かれる
- [× ] 各行がマーキー表示でスクロールする
- [× ] 行ごとに文字数に応じた速度が反映される

## 💭 補足・相談
文字起こしの位置を調整中に録音機能が動作しなくなったため、
リバートを実施、改行＋マーキ表示のみ追加実装しています

## 🚀 マージ後にやること
文字起こし表示場所の修正
