### PR TITLE
feat: チャレンジ記録削除機能実装

### DIFF
--- a/backend/app/api/routers/ai_feedback.py
+++ b/backend/app/api/routers/ai_feedback.py
@@ -202,3 +202,32 @@ async def get_analysis_status(db: Session = Depends(get_db)):
         if total_with_transcript > 0
         else 0,
     }
+
+
+@router.delete("/{challenge_id}")
+async def delete_challenge(challenge_id: str, db: Session = Depends(get_db)):
+    """チャレンジ記録削除"""
+    
+    challenge = db.query(Challenge).filter(Challenge.id == challenge_id).first()
+    
+    if not challenge:
+        raise HTTPException(
+            status_code=404,
+            detail="チャレンジ記録が見つかりません"
+        )
+    
+    try:
+        db.delete(challenge)
+        db.commit()
+        
+        return {
+            "message": "チャレンジ記録を削除しました",
+            "deleted_id": challenge_id
+        }
+        
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"削除中にエラーが発生しました: {str(e)}"
+        )

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -509,4 +509,27 @@ export const api = {
       }
     },
   },
+
+  // チャレンジ削除API
+  challenges: {
+    delete: async (challengeId: string) => {
+      try {
+        const headers = await getAuthHeaders();
+        const res = await fetch(`${API_URL}/api/ai-feedback/${challengeId}`, {
+          method: 'DELETE',
+          headers,
+        });
+
+        if (!res.ok) {
+          const errorData = await res.json();
+          throw new Error(errorData.detail || 'Failed to delete challenge');
+        }
+
+        return res.json();
+      } catch (error) {
+        console.error('チャレンジ記録の削除に失敗:', error);
+        throw error;
+      }
+    },
+  },
 };


### PR DESCRIPTION
📝 やったこと
チャレンジ記録削除機能と文字起こし表示改良を実装しました。
主な実装内容:

バックエンドに削除APIエンドポイント追加
履歴画面に削除ボタンと確認ダイアログ実装
削除後の統計情報自動更新機能
文字起こし結果のマーキー表示・折りたたみ表示実装

🔗 関連 Issue
close #削除機能実装
📸 スクショ
削除機能:

履歴画面の各記録に削除ボタン（ゴミ箱アイコン）表示
削除確認ダイアログ「この記録を削除しますか？削除した記録は元に戻せません。」
削除実行後にリストから記録が消える
今月のチャレンジ回数が正しく更新される

文字起こし表示改良:

チャレンジ画面でのマーキー表示（スクロール）
詳細表示の折りたたみ機能

✅ チェックリスト

 動作確認した
 エラーが出ない
 スマホでも確認した
 バックエンドAPIの動作確認済み（Swagger UI）
 フロントエンドとバックエンドの完全連携確認
 削除機能のテスト完了
 文字起こし表示の動作確認完了

💭 補足・相談
技術実装のポイント:

削除エンドポイント: DELETE /api/ai-feedback/{challenge_id}
権限チェック: 認証済みユーザーのみ削除可能
エラーハンドリング: 404、500エラーに対応
UI/UX: 確認ダイアログによる誤削除防止

機能要件FR-010完全対応:

過去記録を削除可能
ユーザーが任意で削除
確認ダイアログあり

developブランチの最新（文字起こし表示改良）と削除機能実装を統合した完全版です。
🚀 マージ後にやること
特になし（環境変数等の追加設定は不要）