### PR TITLE
chore: Next.js の開発インジケーターをオフにする

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  devIndicators: false,
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## 📝 やったこと
- 開発時に表示される左下の「N」（開発インジケーター）を非表示にする設定を追加
- 変更ファイル: frontend/next.config.js
- 追加内容: devIndicators を false に設定

```
/** @type {import('next').NextConfig} */
const nextConfig = {
  reactStrictMode: true,
  devIndicators: false,
};

module.exports = nextConfig;
```

## 📸 スクショ
<img width="393" height="852" alt="スクリーンショット 2025-08-27 15 21 34" src="https://github.com/user-attachments/assets/a643496a-50fe-461c-961f-9251e19ea220" />



## ✅ チェックリスト

- [ ] 動作確認した（npm run dev で左下の N が消えることを確認）
- [ ] エラーが出ない
- [ ] スマホでも確認した（画面系の場合）

