### PR TITLE
docs: OpenAPI仕様を実装に合わせて修正

### DIFF
--- a/openapi/bud-api.yaml
+++ b/openapi/bud-api.yaml
@@ -17,15 +17,15 @@ servers:
 
 tags:
   - name: health
-    description: ヘルスチェック
+    description: ヘルスチェック関連
   - name: auth
     description: 認証関連のエンドポイント
   - name: children
     description: 子ども管理関連のエンドポイント
-  - name: challenges
-    description: チャレンジ記録関連のエンドポイント
-  - name: transcription
-    description: 音声文字起こし関連のエンドポイント
+  - name: voice
+    description: 音声認識・チャレンジ関連のエンドポイント
+  - name: ai-feedback
+    description: AIフィードバック関連のエンドポイント
 
 components:
   securitySchemes:
@@ -33,125 +33,162 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: Googleログイン後に取得したアクセストークンを使用
+      description: |
+        Firebase Authentication で取得した **IDトークン** を `Authorization: Bearer <idToken>` で送信
 
 paths:
   /health:
     get:
       summary: APIの稼働状態を確認
-      description: APIサーバーが正常に動作しているかを確認するエンドポイント
-      tags:
-        - health
+      tags: [health]
       responses:
-        "200":
+        '200':
           description: APIは正常に稼働中
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  status:
-                    type: string
-                    example: "healthy"
-                  timestamp:
-                    type: string
-                    format: date-time
-                    example: "2024-08-01T12:00:00Z"
+                  status: { type: string, example: healthy }
+                  timestamp: { type: string, format: date-time }
+                  service: { type: string, example: BUD }
+                  version: { type: string, example: 1.0.0 }
 
-  /auth/google:
-    post:
-      summary: Googleアカウントでログイン
-      description: Googleの認証トークンを使用してログインし、アプリ用のアクセストークンを取得
-      tags:
-        - auth
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - idToken
-              properties:
-                idToken:
-                  type: string
-                  description: GoogleのIDトークン
-                  example: "eyJhbGciOiJSUzI1NiIsImtpZCI..."
+  /health/detailed:
+    get:
+      summary: 詳細なヘルスチェック（DB/システム情報）
+      tags: [health]
       responses:
-        "200":
-          description: ログイン成功
+        '200':
+          description: DBやシステムリソースを含む詳細な状態
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  accessToken:
-                    type: string
-                    description: BUDアプリ用のアクセストークン
-                  user:
+                  status: { type: string, example: healthy }
+                  timestamp: { type: string, format: date-time }
+                  service: { type: string }
+                  version: { type: string }
+                  environment: { type: string, example: development }
+                  checks:
                     type: object
                     properties:
-                      id:
-                        type: string
-                        example: "user123"
-                      email:
-                        type: string
-                        example: "parent@example.com"
-                      name:
-                        type: string
-                        example: "テスト太郎"
-        "401":
+                      database:
+                        type: object
+                        properties:
+                          status: { type: string, example: healthy }
+                          response_time_ms: { type: number, example: 12.34 }
+                      async_database:
+                        type: object
+                        properties:
+                          status: { type: string, example: healthy }
+                  system:
+                    type: object
+                    properties:
+                      cpu_percent: { type: number, example: 14.2 }
+                      memory_percent: { type: number, example: 63.5 }
+                      disk_percent: { type: number, example: 71.0 }
+        '503':
+          description: 異常あり
+
+  /health/readiness:
+    get:
+      summary: 準備状態チェック（Kubernetes等で使用）
+      tags: [health]
+      responses:
+        '200':
+          {
+            description: 準備完了,
+            content:
+              {
+                application/json:
+                  {
+                    schema:
+                      {
+                        type: object,
+                        properties:
+                          { status: { type: string, example: ready } },
+                      },
+                  },
+              },
+          }
+        '503': { description: 未準備 }
+
+  /health/liveness:
+    get:
+      summary: 生存確認（Kubernetes等で使用）
+      tags: [health]
+      responses:
+        '200':
+          description: 稼働中
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: alive }
+                  timestamp: { type: string, format: date-time }
+
+  /auth/test:
+    get:
+      summary: Firebase認証テスト
+      description: |
+        Googleログイン後にフロントエンドで取得した **Firebase IDトークン** を
+        `Authorization: Bearer <idToken>` として送信することで認証できます。
+        このエンドポイントは、トークン検証が正しく行えるかを確認するためのものです。
+      tags: [auth]
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: 認証成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string, example: 認証テスト成功 }
+                  user_id: { type: string, example: firebase-uid-123 }
+                  email: { type: string, example: parent@example.com }
+                  name: { type: string, example: 山田太郎 }
+        '401':
           description: 認証失敗
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  error:
-                    type: string
-                    example: "Invalid token"
+                  detail: { type: string, example: 認証に失敗しました }
 
   /children:
     get:
       summary: 子ども一覧を取得
-      description: ログインしている親に紐づく子どもの一覧を取得します
-      tags:
-        - children
+      tags: [children]
       security:
         - BearerAuth: []
       responses:
-        "200":
+        '200':
           description: 子ども一覧の取得成功
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  children:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          example: "child_001"
-                        name:
-                          type: string
-                          example: "たろう"
-                        birthdate:
-                          type: string
-                          example: "2024-08-01T10:00:00Z"
-                          description: 生年月日
-                        createdAt:
-                          type: string
-                          format: date-time
-                          example: "2024-08-01T10:00:00Z"
-
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: { type: string, example: child_001 }
+                    name: { type: string, example: たろう }
+                    birthdate: { type: string, example: 2017-05-01 }
+                    createdAt:
+                      {
+                        type: string,
+                        format: date-time,
+                        example: 2024-08-01T10:00:00Z,
+                      }
     post:
-      summary: 新しい子どもを登録
-      description: 新しい子どもの情報を登録します
-      tags:
-        - children
+      summary: 子どもを登録
+      tags: [children]
       security:
         - BearerAuth: []
       requestBody:
@@ -160,57 +197,62 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - name
-                - grade
+              required: [name, birthdate]
               properties:
-                name:
-                  type: string
-                  example: "はなこ"
-                  description: 子どもの名前
+                name: { type: string, example: はなこ }
                 birthdate:
-                  type: string
-                  example: "2024-08-01T10:00:00Z"
-                  description: 生年月日
+                  {
+                    type: string,
+                    example: 2018-03-20,
+                    description: 生年月日(ISO8601),
+                  }
       responses:
-        "201":
-          description: 子どもの登録成功
+        '201':
+          description: 登録成功
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  id:
-                    type: string
-                    example: "child_002"
-                  name:
-                    type: string
-                    example: "はなこ"
-                  birthdate:
-                    type: string
-                    example: "2024-08-01T10:00:00Z"
-                  createdAt:
-                    type: string
-                    format: date-time
-        "400":
-          description: 入力データが不正
+                  id: { type: string, example: child_002 }
+                  name: { type: string, example: はなこ }
+                  birthdate: { type: string, example: 2018-03-20 }
+                  createdAt: { type: string, format: date-time }
 
   /children/{childId}:
-    put:
-      summary: 子ども情報を更新
-      description: 指定した子どもの情報を更新します
-      tags:
-        - children
+    get:
+      summary: 特定の子どもを取得
+      tags: [children]
       security:
         - BearerAuth: []
       parameters:
         - name: childId
           in: path
           required: true
-          description: 子どものID
-          schema:
-            type: string
-            example: "child_001"
+          schema: { type: string }
+      responses:
+        '200':
+          description: 子ども情報
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  name: { type: string }
+                  birthdate: { type: string }
+                  createdAt: { type: string, format: date-time }
+        '404': { description: 見つからない }
+    put:
+      summary: 子ども情報を更新
+      tags: [children]
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: childId
+          in: path
+          required: true
+          schema: { type: string }
       requestBody:
         required: true
         content:
@@ -218,42 +260,65 @@ paths:
             schema:
               type: object
               properties:
-                name:
-                  type: string
-                  example: "たろう"
-                birthdate:
-                  type: string
-                  example: "2024-08-01T10:00:00Z"
+                name: { type: string }
+                birthdate: { type: string }
       responses:
-        "200":
+        '200':
           description: 更新成功
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  birthdate:
-                    type: string
-                  updatedAt:
-                    type: string
-                    format: date-time
-        "404":
-          description: 子どもが見つからない
+                  id: { type: string }
+                  name: { type: string }
+                  birthdate: { type: string }
+                  createdAt: { type: string, format: date-time }
+        '404': { description: 見つからない }
+    delete:
+      summary: 子どもを削除
+      tags: [children]
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: childId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: 削除成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string, example: 子ども情報を削除しました }
+                  deleted_id: { type: string, example: child_001 }
+        '404': { description: 見つからない }
 
-  /challenges:
+  /api/voice/test:
+    get:
+      summary: 音声APIの動作確認
+      tags: [voice]
+      responses:
+        '200':
+          description: 動作確認OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string, example: Voice API is working }
+                  status: { type: string, example: ok }
+
+  /api/voice/transcribe:
     post:
-      summary: チャレンジ記録を作成
+      summary: 文字起こしを保存し、AIフィードバックを生成
       description: |
-        子どもが外国人と話した記録を保存します。
-
-        - Phase 1: Web Speech APIで取得済みの文字起こしテキストを送信
-        - Phase 2: 音声ファイルIDと文字起こしテキストの両方を送信可能
-      tags:
-        - challenges
+        Web Speech API などで取得した文字起こしを受け取り、Challengeを作成。
+        生成したAIフィードバックを `comment` に保存します。
+      tags: [voice]
       security:
         - BearerAuth: []
       requestBody:
@@ -262,324 +327,208 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - childId
-                - transcription
+              required: [transcript, child_id]
               properties:
-                childId:
-                  type: string
-                  example: "child_001"
-                  description: チャレンジした子どものID
-                transcription:
-                  type: string
-                  example: "Hello! Where are you from?"
-                  description: 話した内容の文字起こし
-                country:
-                  type: string
-                  example: "USA"
-                  description: 相手の出身国（任意）
-                comment:
-                  type: string
-                  example: "初めて自分から話しかけられた！"
-                  description: 親や子どものコメント（任意）
-                challengeType:
-                  type: string
-                  enum: ["wave", "greeting", "question", "conversation"]
-                  example: "greeting"
-                  description: |
-                    チャレンジのレベル
-                    - wave: 手を振る
-                    - greeting: 挨拶する（Hello等）
-                    - question: 質問する（Where are you from?等）
-                    - conversation: 会話する
+                transcript:
+                  { type: string, example: 'Hello! Nice to meet you!' }
+                child_id:
+                  {
+                    type: string,
+                    example: '7f64f2b4-8a9b-4b8b-9d0a-123456789abc',
+                  }
       responses:
-        "201":
-          description: チャレンジ記録の作成成功
+        '200':
+          description: 成功
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  id:
-                    type: string
-                    example: "challenge_001"
-                  childId:
-                    type: string
-                    example: "child_001"
-                  transcription:
-                    type: string
-                  country:
-                    type: string
-                  comment:
-                    type: string
-                  challengeType:
-                    type: string
-                  createdAt:
-                    type: string
-                    format: date-time
-        "400":
-          description: 入力データが不正
+                  transcript_id:
+                    {
+                      type: string,
+                      example: '7f64f2b4-8a9b-4b8b-9d0a-123456789abc',
+                    }
+                  status: { type: string, example: completed }
+                  comment: { type: string, description: 生成されたAIコメント }
+        '400': { description: child_id不正 など }
+        '404': { description: 子どもが見つからない }
+        '500': { description: AIフィードバック生成エラー }
 
+  /api/voice/transcript/{transcriptId}:
     get:
-      summary: チャレンジ一覧を取得
-      description: 条件に応じてチャレンジ記録の一覧を取得します
-      tags:
-        - challenges
-      security:
-        - BearerAuth: []
+      summary: 文字起こし詳細を取得
+      tags: [voice]
+      parameters:
+        - name: transcriptId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: 文字起こし詳細
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  child_id: { type: string }
+                  transcript: { type: string }
+                  comment: { type: string }
+                  created_at: { type: string, format: date-time }
+                  status:
+                    {
+                      type: string,
+                      enum: [processing, completed],
+                      example: completed,
+                    }
+        '404': { description: 見つからない }
+
+  /api/voice/history/{childId}:
+    get:
+      summary: 子どもの音声履歴を取得（完了分）
+      tags: [voice]
       parameters:
         - name: childId
-          in: query
-          required: false
-          description: 特定の子どもの記録のみ取得
-          schema:
-            type: string
-            example: "child_001"
-        - name: limit
-          in: query
-          required: false
-          description: 取得件数の上限
-          schema:
-            type: integer
-            default: 20
-            example: 10
-        - name: offset
-          in: query
-          required: false
-          description: 取得開始位置
-          schema:
-            type: integer
-            default: 0
-            example: 0
+          in: path
+          required: true
+          schema: { type: string }
       responses:
-        "200":
-          description: チャレンジ一覧の取得成功
+        '200':
+          description: 履歴一覧
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  challenges:
+                  child_id: { type: string }
+                  transcripts:
                     type: array
                     items:
                       type: object
                       properties:
-                        id:
-                          type: string
-                          example: "challenge_001"
-                        childId:
-                          type: string
-                          example: "child_001"
-                        childName:
-                          type: string
-                          example: "たろう"
-                          description: 子どもの名前（表示用）
-                        transcription:
-                          type: string
-                          example: "Hello! Nice to meet you!"
-                        country:
-                          type: string
-                          example: "Canada"
-                        challengeType:
-                          type: string
-                          example: "greeting"
-                        createdAt:
-                          type: string
-                          format: date-time
-                  total:
-                    type: integer
-                    example: 25
-                    description: 全体の記録数
-                  hasMore:
-                    type: boolean
-                    example: true
-                    description: さらに記録があるかどうか
+                        id: { type: string }
+                        transcript: { type: string }
+                        comment: { type: string }
+                        created_at: { type: string, format: date-time }
 
-  /challenges/{challengeId}:
+  /api/voice/challenge/{challengeId}:
     get:
       summary: チャレンジ詳細を取得
-      description: 指定したチャレンジ記録の詳細情報を取得します
-      tags:
-        - challenges
-      security:
-        - BearerAuth: []
+      tags: [voice]
       parameters:
         - name: challengeId
           in: path
           required: true
-          description: チャレンジ記録のID
-          schema:
-            type: string
-            example: "challenge_001"
+          schema: { type: string }
       responses:
-        "200":
-          description: チャレンジ詳細の取得成功
+        '200':
+          description: チャレンジ詳細
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  id:
-                    type: string
-                    example: "challenge_001"
-                  childId:
-                    type: string
-                    example: "child_001"
-                  childName:
-                    type: string
-                    example: "たろう"
-                  transcription:
-                    type: string
-                    example: "Hello! Where are you from? I'm from Japan!"
-                  country:
-                    type: string
-                    example: "France"
-                  comment:
-                    type: string
-                    example: "フランスの人と話せた！最初は緊張したけど、優しく答えてくれて嬉しかった。"
-                  challengeType:
-                    type: string
-                    example: "question"
-                  duration:
-                    type: integer
-                    example: 45
-                    description: 録音時間（秒）
-                  aiReview:
-                    type: object
-                    description: AIによるレビュー（MVP段階では固定、将来OpenAI連携予定）
-                    properties:
-                      content:
-                        type: string
-                        example: |
-                          素晴らしいチャレンジでした！🎉
+                  id: { type: string }
+                  child_id: { type: string }
+                  transcript: { type: string }
+                  comment: { type: string }
+                  created_at: { type: string, format: date-time }
+                  status:
+                    {
+                      type: string,
+                      enum: [processing, completed],
+                      example: completed,
+                    }
+        '404': { description: 見つからない }
 
-                          【良かった点】
-                          - 「Hello」の挨拶がはっきりと言えていました
-                          - 「Where are you from?」という質問もできました
-                          - 相手の目を見て話せていたようですね
-
-                          【次のステップ】
-                          - 相手の答えに「That's nice!」と反応してみましょう
-                          - 自分の好きなものも英語で伝えてみましょう
-                      positivePoints:
-                        type: array
-                        items:
-                          type: string
-                        example:
-                          - "はっきりとした声で話せた"
-                          - "質問ができた"
-                          - "笑顔で接することができた"
-                      nextChallenges:
-                        type: array
-                        items:
-                          type: string
-                        example:
-                          - "相手の答えに反応してみよう"
-                          - "自己紹介をしてみよう"
-                          - "好きな食べ物を聞いてみよう"
-                      encouragement:
-                        type: string
-                        example: "この調子で頑張りましょう！英語で話すことがどんどん楽しくなってきますよ！"
-                  createdAt:
-                    type: string
-                    format: date-time
-                  updatedAt:
-                    type: string
-                    format: date-time
-        "404":
-          description: チャレンジ記録が見つからない
-
-  /transcription:
+  /ai-feedback/generate/{challengeId}:
     post:
-      summary: 音声データを文字起こし（Phase 2で実装予定）
-      description: |
-        録音した音声データをテキストに変換します。
-
-        ## 実装フェーズ
-        - **Phase 1 (MVP)**: Web Speech APIを使用したリアルタイム文字起こし
-          - フロントエンドで完結するため、このAPIは使用しない
-          - 録音と同時に文字起こしを実行
-          
-        - **Phase 2 (将来)**: MediaRecorder + Whisper API
-          - MediaRecorder APIで録音した音声ファイルを送信
-          - サーバー側でOpenAI Whisper APIを使用して高精度な文字起こし
-          - このAPIを使用
-      tags:
-        - transcription
-      security:
-        - BearerAuth: []
-      requestBody:
-        required: true
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              required:
-                - audio
-              properties:
-                audio:
-                  type: string
-                  format: binary
-                  description: |
-                    音声ファイル（wav, mp3, m4a, webm等）
-                    MediaRecorder APIで録音したファイル
-                language:
-                  type: string
-                  default: "en"
-                  example: "en"
-                  description: |
-                    音声の言語コード
-                    - en: 英語
-                    - ja: 日本語
+      summary: チャレンジのAIフィードバック生成（保存）
+      tags: [ai-feedback]
+      parameters:
+        - name: challengeId
+          in: path
+          required: true
+          schema: { type: string }
       responses:
-        "200":
-          description: 文字起こし成功
+        '200':
+          description: フィードバック生成成功
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  transcription:
-                    type: string
-                    example: "Hello! Where are you from?"
-                    description: Whisper APIで文字起こしされたテキスト
-                  confidence:
-                    type: number
-                    format: float
-                    minimum: 0
-                    maximum: 1
-                    example: 0.95
-                    description: 文字起こしの信頼度（0-1）
-                  duration:
-                    type: integer
-                    example: 5
-                    description: 音声の長さ（秒）
-                  detectedLanguage:
-                    type: string
-                    example: "en"
-                    description: Whisperが検出した言語
-                  segments:
-                    type: array
-                    description: タイムスタンプ付きのセグメント情報
-                    items:
-                      type: object
-                      properties:
-                        start:
-                          type: number
-                          example: 0.0
-                        end:
-                          type: number
-                          example: 2.5
-                        text:
-                          type: string
-                          example: "Hello!"
-        "400":
-          description: |
-            リクエストエラー
-            - 音声ファイルが不正
-            - サポートされていない形式
-            - ファイルサイズが大きすぎる（25MB以上）
-        "413":
-          description: ファイルサイズが大きすぎる
-        "500":
-          description: Whisper API処理エラー
+                  success: { type: boolean, example: true }
+                  challenge_id: { type: string }
+                  transcript: { type: string }
+                  original_comment: { type: string, nullable: true }
+                  new_feedback: { type: string }
+                  child_age: { type: integer, nullable: true }
+        '404': { description: チャレンジが見つからない }
+        '400': { description: 文字起こしが無い など }
+        '500': { description: 生成失敗 }
+
+  /ai-feedback/preview/{challengeId}:
+    post:
+      summary: チャレンジのAIフィードバックをプレビュー（保存しない）
+      tags: [ai-feedback]
+      parameters:
+        - name: challengeId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: プレビュー成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, example: true }
+                  challenge_id: { type: string }
+                  transcript: { type: string }
+                  current_comment: { type: string, nullable: true }
+                  preview_feedback: { type: string }
+                  child_age: { type: integer, nullable: true }
+        '404': { description: チャレンジが見つからない }
+        '400': { description: 文字起こしが無い など }
+        '500': { description: 生成失敗 }
+
+  /ai-feedback/auto-analyze:
+    post:
+      summary: 未分析チャレンジの一括AI分析
+      tags: [ai-feedback]
+      responses:
+        '200':
+          description: 自動分析の結果
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, example: true }
+                  message: { type: string }
+                  processed_count: { type: integer }
+                  success_count: { type: integer }
+                  error_count: { type: integer }
+        '500': { description: 分析失敗 }
+
+  /ai-feedback/analysis-status:
+    get:
+      summary: 分析状況の統計
+      tags: [ai-feedback]
+      responses:
+        '200':
+          description: 分析状況の統計
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_with_transcript: { type: integer, example: 42 }
+                  analyzed: { type: integer, example: 30 }
+                  unanalyzed: { type: integer, example: 12 }
+                  analysis_rate: { type: number, example: 71.4 }


### PR DESCRIPTION
## 📝 やったこと
- `openapi/bud-api.yaml` を実装に合わせて修正
  - `/auth/google` を削除し、Firebase認証は `/auth/test` に統一
  - `/voice` 系エンドポイントを追加・更新
    - `/api/voice/transcribe`  
    - `/api/voice/transcript/{transcriptId}`  
    - `/api/voice/history/{childId}`  
    - `/api/voice/challenge/{challengeId}`  
    - `/api/voice/test`  
  - `/ai-feedback` 系エンドポイントを追加
    - `/ai-feedback/generate/{challengeId}`  
    - `/ai-feedback/preview/{challengeId}`  
    - `/ai-feedback/auto-analyze`  
    - `/ai-feedback/analysis-status`  
  - `/children` `/health` エンドポイントも実装内容に合わせて整理

## ✅ チェックリスト
- [x] `bud-api.yaml` が Swagger Editor で正しく読み込めることを確認
- [x] 実装済みルーターとエンドポイントが一致している
- [x] 不要な `/auth/google` を削除済み

## 💭 補足・相談
- 今回は **API仕様書（OpenAPI）のみ修正** で、アプリ本体のコード変更はありません
